### PR TITLE
Fix mismatched animal permission names

### DIFF
--- a/app/Http/Controllers/Api/AnimalController.php
+++ b/app/Http/Controllers/Api/AnimalController.php
@@ -58,8 +58,8 @@ class AnimalController extends Controller
     public function index()
     {
         try {
-            $this->authorize('view', new \App\Models\Animal());
-            if (auth()->user()->can('view-animals')) {
+            $this->authorize('viewAny', Animal::class);
+            if (auth()->user()->can('view_any_animal')) {
 
                 $animals = Animal::all();
             } else {

--- a/app/Policies/AnimalPolicy.php
+++ b/app/Policies/AnimalPolicy.php
@@ -7,14 +7,24 @@ use App\Models\Animal;
 
 class AnimalPolicy
 {
+    /**
+     * Determine whether the user can view any animals.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_animal') || $user->can('view_own_animal');
+    }
+
+    /**
+     * Determine whether the user can view a specific animal.
+     */
     public function view(User $user, Animal $animal): bool
     {
-        if ($user->can('view-animals')) {
+        if ($user->can('view_any_animal')) {
             return true;
         }
 
-        if ($animal->user_id === $user->id) {
-
+        if ($user->can('view_own_animal') && $animal->user_id === $user->id) {
             return true;
         }
 
@@ -23,17 +33,16 @@ class AnimalPolicy
 
     public function create(User $user): bool
     {
-        return $user->can('create-animals');
+        return $user->can('create_animal');
     }
 
     public function update(User $user, Animal $animal): bool
     {
-        if ($user->can('edit-animals')) {
+        if ($user->can('edit_any_animal')) {
             return true;
         }
 
-        if ($animal->user_id === $user->id) {
-
+        if ($user->can('edit_own_animal') && $animal->user_id === $user->id) {
             return true;
         }
 
@@ -42,12 +51,11 @@ class AnimalPolicy
 
     public function delete(User $user, Animal $animal): bool
     {
-        if ($user->can('delete-animals')) {
+        if ($user->can('delete_any_animal')) {
             return true;
         }
 
-        if ($animal->user_id === $user->id) {
-
+        if ($user->can('delete_own_animal') && $animal->user_id === $user->id) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- align `AnimalPolicy` with permission names defined in seeders
- use `viewAny` authorization and new permission checks in `AnimalController`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684effefd7708333911a8824fad22f8c