### PR TITLE
Add Store entity with CRUD and policy

### DIFF
--- a/app/Http/Controllers/Api/StoreController.php
+++ b/app/Http/Controllers/Api/StoreController.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreStoreRequest;
+use App\Http\Requests\UpdateStoreRequest;
+use App\Http\Resources\StoreResource;
+use App\Services\StoreService;
+use App\Services\ApiService;
+use App\Models\Store;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Tag(name="Stores", description="Gestion des boutiques")
+ */
+class StoreController extends Controller
+{
+    protected StoreService $storeService;
+
+    public function __construct(StoreService $storeService)
+    {
+        $this->storeService = $storeService;
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/stores",
+     *     tags={"Stores"},
+     *     summary="Liste des boutiques",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Liste récupérée"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        try {
+            $this->authorize('view', new Store());
+            $stores = $this->storeService->getAll();
+            return ApiService::response(StoreResource::collection($stores), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/stores",
+     *     tags={"Stores"},
+     *     summary="Créer une boutique",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="provider_id", type="integer", example=1),
+     *         @OA\Property(property="name", type="object", example={"fr":"Ma boutique"}),
+     *         @OA\Property(property="description", type="object", example={"fr":"Description"})
+     *     )),
+     *     @OA\Response(response=201, description="Boutique créée"),
+     *     @OA\Response(response=422, description="Données invalides"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function store(StoreStoreRequest $request): JsonResponse
+    {
+        try {
+            $this->authorize('create', new Store());
+            $store = $this->storeService->create($request->validated());
+            return ApiService::response(new StoreResource($store), 201);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/stores/{id}",
+     *     tags={"Stores"},
+     *     summary="Afficher une boutique",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Boutique trouvée"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function show(int $id): JsonResponse
+    {
+        try {
+            $store = $this->storeService->find($id);
+            $this->authorize('view', $store);
+            return ApiService::response(new StoreResource($store), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/stores/{id}",
+     *     tags={"Stores"},
+     *     summary="Mettre à jour une boutique",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Boutique mise à jour"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=422, description="Données invalides"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function update(UpdateStoreRequest $request, int $id): JsonResponse
+    {
+        try {
+            $store = $this->storeService->find($id);
+            $this->authorize('update', $store);
+            $updated = $this->storeService->update($store, $request->validated());
+            return ApiService::response(new StoreResource($updated), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/stores/{id}",
+     *     tags={"Stores"},
+     *     summary="Supprimer une boutique",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Supprimé"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $store = $this->storeService->find($id);
+            $this->authorize('delete', $store);
+            $this->storeService->delete($store);
+            return ApiService::response(['message' => 'Store deleted'], 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store not found', 404);
+        }
+    }
+}

--- a/app/Http/Requests/StoreStoreRequest.php
+++ b/app/Http/Requests/StoreStoreRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'provider_id'        => 'required|exists:providers,id|unique:stores,provider_id',
+            'name'               => 'required|array',
+            'name.*'             => 'required|string|max:255',
+            'description'        => 'nullable|array',
+            'description.*'      => 'nullable|string',
+            'address'            => 'nullable|string|max:255',
+            'phone'              => 'nullable|string|max:20',
+            'email'              => 'nullable|email',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateStoreRequest.php
+++ b/app/Http/Requests/UpdateStoreRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $storeId = $this->route('store');
+
+        return [
+            'provider_id'   => 'sometimes|exists:providers,id|unique:stores,provider_id,'.$storeId,
+            'name'          => 'sometimes|array',
+            'name.*'        => 'sometimes|string|max:255',
+            'description'   => 'nullable|array',
+            'description.*' => 'nullable|string',
+            'address'       => 'sometimes|string|max:255',
+            'phone'         => 'sometimes|string|max:20',
+            'email'         => 'sometimes|email',
+        ];
+    }
+}

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'          => $this->id,
+            'provider_id' => $this->provider_id,
+            'name'        => $this->getTranslations('name'),
+            'description' => $this->getTranslations('description'),
+            'address'     => $this->address,
+            'phone'       => $this->phone,
+            'email'       => $this->email,
+            'created_at'  => $this->created_at->format('Y-m-d H:i'),
+            'updated_at'  => $this->updated_at->format('Y-m-d H:i'),
+        ];
+    }
+}

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Translatable\HasTranslations;
+
+class Store extends Model
+{
+    use HasFactory, HasTranslations;
+
+    protected $fillable = [
+        'provider_id',
+        'name',
+        'description',
+        'address',
+        'phone',
+        'email',
+    ];
+
+    public $translatable = ['name', 'description'];
+
+    public function provider()
+    {
+        return $this->belongsTo(Provider::class);
+    }
+
+    public function products()
+    {
+        return $this->hasMany(Product::class);
+    }
+
+    public function orders()
+    {
+        return $this->hasMany(Order::class);
+    }
+}

--- a/app/Policies/StorePolicy.php
+++ b/app/Policies/StorePolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Store;
+use App\Models\User;
+
+class StorePolicy
+{
+    public function view(User $user, Store $store): bool
+    {
+        if ($user->can('view_any_store')) {
+            return true;
+        }
+
+        if ($user->can('view_own_store') && optional($store->provider)->user_id === $user->id) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_store');
+    }
+
+    public function update(User $user, Store $store): bool
+    {
+        if ($user->can('edit_any_store')) {
+            return true;
+        }
+
+        if ($user->can('edit_own_store') && optional($store->provider)->user_id === $user->id) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function delete(User $user, Store $store): bool
+    {
+        if ($user->can('delete_any_store')) {
+            return true;
+        }
+
+        if ($user->can('delete_own_store') && optional($store->provider)->user_id === $user->id) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -11,6 +11,7 @@ use App\Models\Collar;
 use App\Models\Category;
 use App\Models\Review;
 use App\Models\ProviderService;
+use App\Models\Store;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Gate;
@@ -25,6 +26,7 @@ use App\Policies\RolePolicy;
 use App\Policies\PermissionPolicy;
 use App\Policies\ReviewPolicy;
 use App\Policies\ProviderServicePolicy;
+use App\Policies\StorePolicy;
 use App\Policies\UserPolicy;
 
 class AuthServiceProvider extends ServiceProvider
@@ -45,6 +47,7 @@ class AuthServiceProvider extends ServiceProvider
         Permission::class      => PermissionPolicy::class,
         Review::class          => ReviewPolicy::class,
         ProviderService::class => ProviderServicePolicy::class,
+        Store::class           => StorePolicy::class,
         User::class            => UserPolicy::class,
     ];
 

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Collection;
+
+class StoreService
+{
+    public function getAll(): Collection
+    {
+        return Store::all();
+    }
+
+    public function find(int $id): Store
+    {
+        return Store::findOrFail($id);
+    }
+
+    public function create(array $data): Store
+    {
+        $store = new Store();
+        $store->provider_id = $data['provider_id'];
+        $store->setTranslations('name', $data['name']);
+        if (isset($data['description'])) {
+            $store->setTranslations('description', $data['description']);
+        }
+        $store->address = $data['address'] ?? null;
+        $store->phone   = $data['phone'] ?? null;
+        $store->email   = $data['email'] ?? null;
+        $store->save();
+        return $store;
+    }
+
+    public function update(Store $store, array $data): Store
+    {
+        if (isset($data['provider_id'])) {
+            $store->provider_id = $data['provider_id'];
+        }
+        if (isset($data['name'])) {
+            $store->setTranslations('name', $data['name']);
+        }
+        if (isset($data['description'])) {
+            $store->setTranslations('description', $data['description']);
+        }
+        if (isset($data['address'])) {
+            $store->address = $data['address'];
+        }
+        if (isset($data['phone'])) {
+            $store->phone = $data['phone'];
+        }
+        if (isset($data['email'])) {
+            $store->email = $data['email'];
+        }
+        $store->save();
+        return $store;
+    }
+
+    public function delete(Store $store): void
+    {
+        $store->delete();
+    }
+}

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use App\Models\Provider;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StoreFactory extends Factory
+{
+    protected $model = Store::class;
+
+    public function definition()
+    {
+        return [
+            'provider_id' => Provider::factory(),
+            'name'        => [
+                'en' => $this->faker->company,
+                'fr' => $this->faker->company,
+            ],
+            'description' => [
+                'en' => $this->faker->sentence,
+                'fr' => $this->faker->sentence,
+            ],
+            'address'     => $this->faker->address,
+            'phone'       => $this->faker->phoneNumber,
+            'email'       => $this->faker->unique()->companyEmail,
+        ];
+    }
+}

--- a/database/migrations/2025_05_01_101259_create_stores_table.php
+++ b/database/migrations/2025_05_01_101259_create_stores_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('stores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('provider_id')->unique()->constrained()->onDelete('cascade');
+            $table->json('name');
+            $table->json('description')->nullable();
+            $table->string('address')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('email')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stores');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             CategorySeeder::class,
             RolePermissionSeeder::class,
             ServiceSeeder::class,
+            StoreSeeder::class,
             //UserSeeder::class,
 
         ]);

--- a/database/seeders/StoreSeeder.php
+++ b/database/seeders/StoreSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Store;
+
+class StoreSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Store::factory()->count(5)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Api\{
     PermissionController,
     UserController,
     ProviderServiceController,
+    StoreController,
     PaymentController,
     StripeWebhookController
 };
@@ -85,6 +86,7 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('providers', ProviderController::class);
         Route::apiResource('services', ServiceController::class);
         Route::apiResource('categories', CategoryController::class);
+        Route::apiResource('stores', StoreController::class);
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- introduce `Store` model with translations and relationships
- migration for stores table
- factory & seeder for stores
- authorization policy and registration
- service handling store logic
- request/response resources
- controller with Swagger docs
- API route `/stores`

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c36c004048333960a742ab2d5ad1b