### PR TITLE
Add Product store relation and controller

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use App\Services\ApiService;
+use App\Services\ProductService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Tag(name="Products", description="Gestion des produits")
+ */
+class ProductController extends Controller
+{
+    protected ProductService $productService;
+
+    public function __construct(ProductService $productService)
+    {
+        $this->productService = $productService;
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/products",
+     *     tags={"Products"},
+     *     summary="Liste des produits",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Liste récupérée"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        try {
+            $this->authorize('view', new Product());
+            $products = Product::with(['category', 'store'])->get();
+            return ApiService::response(ProductResource::collection($products), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/products",
+     *     tags={"Products"},
+     *     summary="Créer un produit",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="store_id", type="integer", example=1),
+     *         @OA\Property(property="product_category_id", type="integer", example=1),
+     *         @OA\Property(property="name", type="object", example={"fr":"Produit"}),
+     *         @OA\Property(property="description", type="object", example={"fr":"Description"})
+     *     )),
+     *     @OA\Response(response=201, description="Produit créé"),
+     *     @OA\Response(response=422, description="Données invalides"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function store(StoreProductRequest $request): JsonResponse
+    {
+        try {
+            $this->authorize('create', new Product());
+            $product = $this->productService->create($request->validated());
+            return ApiService::response(new ProductResource($product), 201);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/products/{id}",
+     *     tags={"Products"},
+     *     summary="Afficher un produit",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Détails du produit"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function show(int $id): JsonResponse
+    {
+        try {
+            $product = Product::with(['category', 'store'])->findOrFail($id);
+            $this->authorize('view', $product);
+            return ApiService::response(new ProductResource($product), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Product not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/products/{id}",
+     *     tags={"Products"},
+     *     summary="Mettre à jour un produit",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Produit mis à jour"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=422, description="Données invalides"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function update(UpdateProductRequest $request, int $id): JsonResponse
+    {
+        try {
+            $product = Product::findOrFail($id);
+            $this->authorize('update', $product);
+            $updated = $this->productService->update($product, $request->validated());
+            return ApiService::response(new ProductResource($updated), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Product not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/products/{id}",
+     *     tags={"Products"},
+     *     summary="Supprimer un produit",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Supprimé"),
+     *     @OA\Response(response=404, description="Introuvable"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        try {
+            $product = Product::findOrFail($id);
+            $this->authorize('delete', $product);
+            $this->productService->delete($product);
+            return ApiService::response(['message' => 'Product deleted'], 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Product not found', 404);
+        }
+    }
+}
+

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -11,7 +11,7 @@ class StoreProductRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,6 +22,7 @@ class StoreProductRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'store_id' => 'required|exists:stores,id',
             'product_category_id' => 'required|exists:product_categories,id',
             'name' => 'required|array',
             'name.*' => 'required|string|max:255',

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -11,7 +11,7 @@ class UpdateProductRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -23,6 +23,7 @@ class UpdateProductRequest extends FormRequest
     {
         return [
             'product_category_id' => 'required|exists:product_categories,id',
+            'store_id' => 'sometimes|exists:stores,id',
             'name' => 'required|array',
             'name.*' => 'required|string|max:255',
             'description' => 'nullable|array',

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -13,6 +13,7 @@ class Product extends Model
 
     protected $fillable = [
         'product_category_id',
+        'store_id',
         'name',
         'description',
         'price',
@@ -25,6 +26,11 @@ class Product extends Model
     public function category()
     {
         return $this->belongsTo(ProductCategory::class, 'product_category_id');
+    }
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
     }
 }
 

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -10,6 +10,7 @@ class ProductService
     {
         $product = new Product();
         $product->product_category_id = $data['product_category_id'];
+        $product->store_id = $data['store_id'];
         $product->price = $data['price'];
         $product->stock = $data['stock'];
         $product->image = $data['image'] ?? null;
@@ -22,6 +23,9 @@ class ProductService
     public function update(Product $product, array $data): Product
     {
         $product->product_category_id = $data['product_category_id'];
+        if (isset($data['store_id'])) {
+            $product->store_id = $data['store_id'];
+        }
         $product->price = $data['price'];
         $product->stock = $data['stock'];
         $product->image = $data['image'] ?? null;
@@ -36,3 +40,4 @@ class ProductService
         $product->delete();
     }
 }
+

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\ProductCategory;
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition()
+    {
+        return [
+            'product_category_id' => ProductCategory::factory(),
+            'store_id'            => Store::factory(),
+            'name'                => [
+                'en' => $this->faker->word,
+                'fr' => $this->faker->word,
+            ],
+            'description'         => [
+                'en' => $this->faker->sentence,
+                'fr' => $this->faker->sentence,
+            ],
+            'price'               => $this->faker->randomFloat(2, 1, 100),
+            'stock'               => $this->faker->numberBetween(0, 100),
+            'image'               => $this->faker->imageUrl(),
+        ];
+    }
+}
+

--- a/database/migrations/2025_03_23_163323_create_products_table.php
+++ b/database/migrations/2025_03_23_163323_create_products_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('products', function (Blueprint $table) {
             $table->id();
             $table->foreignId('product_category_id')->constrained()->onDelete('cascade');
+            $table->foreignId('store_id')->constrained()->onDelete('cascade');
             $table->json('name');
             $table->json('description')->nullable();
             $table->decimal('price', 10, 2);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             RolePermissionSeeder::class,
             ServiceSeeder::class,
             StoreSeeder::class,
+            ProductSeeder::class,
             //UserSeeder::class,
 
         ]);

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Product;
+
+class ProductSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Product::factory()->count(10)->create();
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\{
     UserController,
     ProviderServiceController,
     StoreController,
+    ProductController,
     PaymentController,
     StripeWebhookController
 };
@@ -87,6 +88,7 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('services', ServiceController::class);
         Route::apiResource('categories', CategoryController::class);
         Route::apiResource('stores', StoreController::class);
+        Route::apiResource('products', ProductController::class);
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- link products to stores in migration and model
- update product service and requests for store relation
- add REST ProductController with Swagger docs
- register product routes
- provide factory and seeder for products

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c38722bd08333b6ec6b96192421a5