### PR TITLE
Fix request authorization and add tests

### DIFF
--- a/app/Http/Requests/StoreOrderRequest.php
+++ b/app/Http/Requests/StoreOrderRequest.php
@@ -11,7 +11,8 @@ class StoreOrderRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        // Authorization is handled in the controller via policies
+        return true;
     }
 
     /**

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -11,6 +11,7 @@ class StoreProductRequest extends FormRequest
      */
     public function authorize(): bool
     {
+        // Authorization is handled in the controller via policies
         return true;
     }
 

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -11,6 +11,7 @@ class UpdateProductRequest extends FormRequest
      */
     public function authorize(): bool
     {
+        // Authorization is handled in the controller via policies
         return true;
     }
 

--- a/tests/Feature/Requests/OrderRequestTest.php
+++ b/tests/Feature/Requests/OrderRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\StoreOrderRequest;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class OrderRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_order_request_passes_validation_when_authorized(): void
+    {
+        $product = Product::factory()->create();
+
+        $data = [
+            'items' => [
+                [
+                    'product_id' => $product->id,
+                    'quantity' => 1,
+                ],
+            ],
+        ];
+
+        $request = new StoreOrderRequest();
+
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+}

--- a/tests/Feature/Requests/ProductRequestTest.php
+++ b/tests/Feature/Requests/ProductRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Models\ProductCategory;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class ProductRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_product_request_passes_validation_when_authorized(): void
+    {
+        $store = Store::factory()->create();
+        $category = ProductCategory::create([
+            'name' => ['en' => 'Cat'],
+            'description' => ['en' => 'Desc'],
+        ]);
+
+        $data = [
+            'store_id' => $store->id,
+            'product_category_id' => $category->id,
+            'name' => ['en' => 'Product'],
+            'description' => ['en' => 'Desc'],
+            'price' => 10,
+            'stock' => 5,
+            'image' => 'img.jpg',
+        ];
+
+        $request = new StoreProductRequest();
+
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+
+    public function test_update_product_request_passes_validation_when_authorized(): void
+    {
+        $store = Store::factory()->create();
+        $category = ProductCategory::create([
+            'name' => ['en' => 'Cat'],
+            'description' => ['en' => 'Desc'],
+        ]);
+
+        $data = [
+            'product_category_id' => $category->id,
+            'store_id' => $store->id,
+            'name' => ['en' => 'Product'],
+            'description' => ['en' => 'Desc'],
+            'price' => 10,
+            'stock' => 5,
+            'image' => 'img.jpg',
+        ];
+
+        $request = new UpdateProductRequest();
+
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary
- enable authorization in StoreProductRequest, UpdateProductRequest, StoreOrderRequest
- test that product requests validate when authorized
- test that order request validates when authorized

## Testing
- `./vendor/bin/phpunit --testsuite Feature` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c3d3c5df48333889e39c354fee4ca