### PR TITLE
Add read-only OrderItem endpoints

### DIFF
--- a/app/Http/Controllers/Api/OrderItemController.php
+++ b/app/Http/Controllers/Api/OrderItemController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\OrderItemResource;
+use App\Models\Order;
+use App\Services\ApiService;
+use App\Services\OrderItemService;
+use Illuminate\Http\JsonResponse;
+
+class OrderItemController extends Controller
+{
+    public function __construct(private OrderItemService $orderItemService) {}
+
+    /**
+     * @OA\Get(
+     *     path="/orders/{order}/items",
+     *     tags={"Orders"},
+     *     summary="Liste les items d’une commande",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="order", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Liste des items"),
+     *     @OA\Response(response=404, description="Commande introuvable")
+     * )
+     */
+    public function index(Order $order): JsonResponse
+    {
+        try {
+            $this->authorize('view', $order);
+            $items = $this->orderItemService->listByOrder($order);
+            return ApiService::response(OrderItemResource::collection($items), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Order not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/order-items/{id}",
+     *     tags={"Orders"},
+     *     summary="Voir un item de commande",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Item trouvé"),
+     *     @OA\Response(response=404, description="Item introuvable")
+     * )
+     */
+    public function show(int $id): JsonResponse
+    {
+        try {
+            $item = $this->orderItemService->find($id);
+            $this->authorize('view', $item->order);
+            return ApiService::response(new OrderItemResource($item), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Order item not found', 404);
+        }
+    }
+}

--- a/app/Services/OrderItemService.php
+++ b/app/Services/OrderItemService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Database\Eloquent\Collection;
+
+class OrderItemService
+{
+    public function listByOrder(Order $order): Collection
+    {
+        return $order->items()->with('product')->get();
+    }
+
+    public function find(int $id): OrderItem
+    {
+        return OrderItem::with(['product', 'order.store'])->findOrFail($id);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Api\{
     StoreController,
     ProductController,
     OrderController,
+    OrderItemController,
     PaymentController,
     StripeWebhookController
 };
@@ -94,7 +95,10 @@ Route::prefix('v1')->group(function () {
         Route::prefix('orders')->group(function () {
             Route::get('/', [OrderController::class, 'index']);
             Route::get('/{id}', [OrderController::class, 'show']);
+            Route::get('/{order}/items', [OrderItemController::class, 'index']);
         });
+
+        Route::get('order-items/{id}', [OrderItemController::class, 'show']);
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose order item listing and detail endpoints
- create `OrderItemController` and `OrderItemService`
- wire new controller via API routes

## Testing
- `php -v` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c6a4a2d5c8333b50212d8da156299