### PR TITLE
Refactor stores to use user_id

### DIFF
--- a/app/Http/Requests/StoreStoreRequest.php
+++ b/app/Http/Requests/StoreStoreRequest.php
@@ -14,7 +14,7 @@ class StoreStoreRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'provider_id'        => 'required|exists:providers,id|unique:stores,provider_id',
+            'user_id'            => 'required|exists:users,id|unique:stores,user_id',
             'name'               => 'required|array',
             'name.*'             => 'required|string|max:255',
             'description'        => 'nullable|array',
@@ -22,6 +22,7 @@ class StoreStoreRequest extends FormRequest
             'address'            => 'nullable|string|max:255',
             'phone'              => 'nullable|string|max:20',
             'email'              => 'nullable|email',
+            'status'             => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateStoreRequest.php
+++ b/app/Http/Requests/UpdateStoreRequest.php
@@ -16,7 +16,7 @@ class UpdateStoreRequest extends FormRequest
         $storeId = $this->route('store');
 
         return [
-            'provider_id'   => 'sometimes|exists:providers,id|unique:stores,provider_id,'.$storeId,
+            'user_id'       => 'sometimes|exists:users,id|unique:stores,user_id,'.$storeId,
             'name'          => 'sometimes|array',
             'name.*'        => 'sometimes|string|max:255',
             'description'   => 'nullable|array',
@@ -24,6 +24,7 @@ class UpdateStoreRequest extends FormRequest
             'address'       => 'sometimes|string|max:255',
             'phone'         => 'sometimes|string|max:20',
             'email'         => 'sometimes|email',
+            'status'        => 'sometimes|string',
         ];
     }
 }

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -11,12 +11,13 @@ class StoreResource extends JsonResource
     {
         return [
             'id'          => $this->id,
-            'provider_id' => $this->provider_id,
+            'user_id'     => $this->user_id,
             'name'        => $this->getTranslations('name'),
             'description' => $this->getTranslations('description'),
             'address'     => $this->address,
             'phone'       => $this->phone,
             'email'       => $this->email,
+            'status'      => $this->status,
             'created_at'  => $this->created_at->format('Y-m-d H:i'),
             'updated_at'  => $this->updated_at->format('Y-m-d H:i'),
         ];

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -11,19 +11,20 @@ class Store extends Model
     use HasFactory, HasTranslations;
 
     protected $fillable = [
-        'provider_id',
+        'user_id',
         'name',
         'description',
         'address',
         'phone',
         'email',
+        'status',
     ];
 
     public $translatable = ['name', 'description'];
 
-    public function provider()
+    public function user()
     {
-        return $this->belongsTo(Provider::class);
+        return $this->belongsTo(User::class);
     }
 
     public function products()

--- a/app/Policies/OrderPolicy.php
+++ b/app/Policies/OrderPolicy.php
@@ -21,7 +21,7 @@ class OrderPolicy
             if ($order->user_id === $user->id) {
                 return true;
             }
-            return $order->store && $order->store->provider && $order->store->provider->user_id === $user->id;
+            return $order->store && $order->store->user_id === $user->id;
         }
 
         return false;

--- a/app/Policies/StorePolicy.php
+++ b/app/Policies/StorePolicy.php
@@ -13,7 +13,7 @@ class StorePolicy
             return true;
         }
 
-        if ($user->can('view_own_store') && optional($store->provider)->user_id === $user->id) {
+        if ($user->can('view_own_store') && $store->user_id === $user->id) {
             return true;
         }
 
@@ -31,7 +31,7 @@ class StorePolicy
             return true;
         }
 
-        if ($user->can('edit_own_store') && optional($store->provider)->user_id === $user->id) {
+        if ($user->can('edit_own_store') && $store->user_id === $user->id) {
             return true;
         }
 
@@ -44,7 +44,7 @@ class StorePolicy
             return true;
         }
 
-        if ($user->can('delete_own_store') && optional($store->provider)->user_id === $user->id) {
+        if ($user->can('delete_own_store') && $store->user_id === $user->id) {
             return true;
         }
 

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -20,7 +20,7 @@ class StoreService
     public function create(array $data): Store
     {
         $store = new Store();
-        $store->provider_id = $data['provider_id'];
+        $store->user_id = $data['user_id'];
         $store->setTranslations('name', $data['name']);
         if (isset($data['description'])) {
             $store->setTranslations('description', $data['description']);
@@ -28,14 +28,15 @@ class StoreService
         $store->address = $data['address'] ?? null;
         $store->phone   = $data['phone'] ?? null;
         $store->email   = $data['email'] ?? null;
+        $store->status  = $data['status'] ?? 'active';
         $store->save();
         return $store;
     }
 
     public function update(Store $store, array $data): Store
     {
-        if (isset($data['provider_id'])) {
-            $store->provider_id = $data['provider_id'];
+        if (isset($data['user_id'])) {
+            $store->user_id = $data['user_id'];
         }
         if (isset($data['name'])) {
             $store->setTranslations('name', $data['name']);
@@ -51,6 +52,9 @@ class StoreService
         }
         if (isset($data['email'])) {
             $store->email = $data['email'];
+        }
+        if (isset($data['status'])) {
+            $store->status = $data['status'];
         }
         $store->save();
         return $store;

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Store;
-use App\Models\Provider;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class StoreFactory extends Factory
@@ -13,7 +13,7 @@ class StoreFactory extends Factory
     public function definition()
     {
         return [
-            'provider_id' => Provider::factory(),
+            'user_id' => User::factory(),
             'name'        => [
                 'en' => $this->faker->company,
                 'fr' => $this->faker->company,
@@ -25,6 +25,7 @@ class StoreFactory extends Factory
             'address'     => $this->faker->address,
             'phone'       => $this->faker->phoneNumber,
             'email'       => $this->faker->unique()->companyEmail,
+            'status'      => 'active',
         ];
     }
 }

--- a/database/migrations/2025_05_01_101259_create_stores_table.php
+++ b/database/migrations/2025_05_01_101259_create_stores_table.php
@@ -10,12 +10,13 @@ return new class extends Migration
     {
         Schema::create('stores', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('provider_id')->unique()->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->unique()->constrained()->onDelete('cascade');
             $table->json('name');
             $table->json('description')->nullable();
             $table->string('address')->nullable();
             $table->string('phone')->nullable();
             $table->string('email')->nullable();
+            $table->string('status')->default('active');
             $table->timestamps();
         });
     }

--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -58,7 +58,7 @@ class TestDataSeeder extends Seeder
 
             // Create store
             $store = Store::factory()->create([
-                'provider_id' => $provider->id,
+                'user_id' => $providerUser->id,
                 'name' => ['en' => "Store {$i}", 'fr' => "Magasin {$i}"],
             ]);
             $stores[] = $store;


### PR DESCRIPTION
## Summary
- connect stores directly to users
- keep new status column in stores
- update store validation and service logic
- adjust policies, resources and seed data

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d114b277c83339a44bdff59594e21