### PR TITLE
Add status attribute to products

### DIFF
--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -32,6 +32,7 @@ class StoreProductRequest extends FormRequest
             'price' => 'required|numeric|min:0',
             'stock' => 'required|integer|min:0',
             'image' => 'nullable|string',
+            'status' => 'nullable|string',
         ];
-    }    
+    }
 }

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -32,6 +32,7 @@ class UpdateProductRequest extends FormRequest
             'price' => 'required|numeric|min:0',
             'stock' => 'required|integer|min:0',
             'image' => 'nullable|string',
+            'status' => 'sometimes|string',
         ];
-    }    
+    }
 }

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -22,6 +22,7 @@ class ProductResource extends JsonResource
             'price' => $this->price,
             'stock' => $this->stock,
             'image' => $this->image,
+            'status' => $this->status,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -19,6 +19,7 @@ class Product extends Model
         'price',
         'stock',
         'image',
+        'status',
     ];
 
     public $translatable = ['name', 'description'];

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -14,6 +14,7 @@ class ProductService
         $product->price = $data['price'];
         $product->stock = $data['stock'];
         $product->image = $data['image'] ?? null;
+        $product->status = $data['status'] ?? 'active';
         $product->setTranslations('name', $data['name']);
         $product->setTranslations('description', $data['description'] ?? []);
         $product->save();
@@ -29,6 +30,9 @@ class ProductService
         $product->price = $data['price'];
         $product->stock = $data['stock'];
         $product->image = $data['image'] ?? null;
+        if (isset($data['status'])) {
+            $product->status = $data['status'];
+        }
         $product->setTranslations('name', $data['name']);
         $product->setTranslations('description', $data['description'] ?? []);
         $product->save();

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -27,6 +27,7 @@ class ProductFactory extends Factory
             'price'               => $this->faker->randomFloat(2, 1, 100),
             'stock'               => $this->faker->numberBetween(0, 100),
             'image'               => $this->faker->imageUrl(),
+            'status'              => 'active',
         ];
     }
 }

--- a/database/migrations/2025_03_23_163323_create_products_table.php
+++ b/database/migrations/2025_03_23_163323_create_products_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->decimal('price', 10, 2);
             $table->integer('stock')->default(0);
             $table->string('image')->nullable();
+            $table->string('status')->default('active');
             $table->timestamps();
         });
     }

--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -79,6 +79,7 @@ class TestDataSeeder extends Seeder
                     'price' => random_int(5, 100),
                     'stock' => 20,
                     'image' => null,
+                    'status' => 'active',
                 ]);
             }
         }


### PR DESCRIPTION
## Summary
- add `status` column to product migration
- include `status` in Product model, service, requests, and resource
- set default status in `ProductFactory`
- update `TestDataSeeder` to insert product status

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d168d25048333b3cf8ad88f8e3c2a