### PR TITLE
Fix PSR‑4 namespaces for feature tests

### DIFF
--- a/tests/Feature/Auth/RefreshTokenTest.php
+++ b/tests/Feature/Auth/RefreshTokenTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Auth;
 
 // tests/Feature/Auth/RefreshTokenTest.php
 
 use Tests\TestCase;
+use App\Models\User;
 
 class RefreshTokenTest extends TestCase
 {

--- a/tests/Feature/Requests/OrderRequestTest.php
+++ b/tests/Feature/Requests/OrderRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Requests;
 
 use App\Http\Requests\StoreOrderRequest;
 use App\Models\Product;

--- a/tests/Feature/Requests/ProductRequestTest.php
+++ b/tests/Feature/Requests/ProductRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Requests;
 
 use App\Http\Requests\StoreProductRequest;
 use App\Http\Requests\UpdateProductRequest;


### PR DESCRIPTION
## Summary
- adjust namespaces for request tests and RefreshTokenTest
- include User model import for RefreshTokenTest
- run `composer dump-autoload` to update autoloader (fails due to missing dependencies)

## Testing
- `composer dump-autoload` *(fails: Class "Illuminate\Foundation\Application" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5ca2e6cc8333a63e73c0dd9a5e0f