### PR TITLE
Add ProductCategory factory

### DIFF
--- a/database/factories/ProductCategoryFactory.php
+++ b/database/factories/ProductCategoryFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProductCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductCategoryFactory extends Factory
+{
+    protected $model = ProductCategory::class;
+
+    public function definition()
+    {
+        return [
+            'name' => [
+                'en' => $this->faker->word,
+                'fr' => $this->faker->word,
+            ],
+            'description' => $this->faker->optional()->passthrough([
+                'en' => $this->faker->sentence,
+                'fr' => $this->faker->sentence,
+            ]),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add a factory for `ProductCategory` with translatable name and optional description
- dump the autoloader for composer

## Testing
- `composer dump-autoload --no-scripts`
- `php artisan migrate --force`
- `php artisan db:seed` *(fails: `SQLSTATE[HY000]: General error: 1 table order_items has no column named price`)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c995c8c8333bc68f144713967f5