### PR TITLE
Fix seeder to use unit_price column

### DIFF
--- a/database/seeders/MarketplaceSeeder.php
+++ b/database/seeders/MarketplaceSeeder.php
@@ -118,10 +118,10 @@ class MarketplaceSeeder extends Seeder
         foreach ($selected as $product) {
             $qty = rand(1, 2);
             OrderItem::create([
-                'order_id' => $order->id,
+                'order_id'  => $order->id,
                 'product_id' => $product->id,
-                'quantity' => $qty,
-                'price' => $product->price
+                'quantity'  => $qty,
+                'unit_price' => $product->price,
             ]);
             $total += $product->price * $qty;
         }


### PR DESCRIPTION
## Summary
- use `unit_price` column for creating order items in `MarketplaceSeeder`

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0a4288f8833381f4036c91f665ad