### PR TITLE
Add cart controller and routes

### DIFF
--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCartItemRequest;
+use App\Http\Requests\UpdateCartItemRequest;
+use App\Http\Resources\CartResource;
+use App\Models\CartItem;
+use App\Services\ApiService;
+use App\Services\CartService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Tag(name="Cart", description="Gestion du panier")
+ */
+class CartController extends Controller
+{
+    public function __construct(private CartService $cartService)
+    {
+        $this->middleware('auth:sanctum');
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/cart",
+     *     tags={"Cart"},
+     *     summary="Lister les articles du panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Liste des articles")
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        $items = CartItem::with('product')
+            ->where('user_id', auth()->id())
+            ->get();
+
+        return ApiService::response(CartResource::collection($items), 200);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/cart/add",
+     *     tags={"Cart"},
+     *     summary="Ajouter un article au panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="product_id", type="integer", example=1),
+     *         @OA\Property(property="quantity", type="integer", example=2)
+     *     )),
+     *     @OA\Response(response=201, description="Article ajouté")
+     * )
+     */
+    public function add(StoreCartItemRequest $request): JsonResponse
+    {
+        $item = $this->cartService->addToCart($request->validated());
+        $item->load('product');
+
+        return ApiService::response(new CartResource($item), 201);
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/cart/update/{item}",
+     *     tags={"Cart"},
+     *     summary="Mettre à jour un article du panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="item", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         @OA\Property(property="quantity", type="integer", example=1)
+     *     )),
+     *     @OA\Response(response=200, description="Article mis à jour")
+     * )
+     */
+    public function update(UpdateCartItemRequest $request, CartItem $item): JsonResponse
+    {
+        $item->update(['quantity' => $request->quantity]);
+        $item->load('product');
+
+        return ApiService::response(new CartResource($item), 200);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/cart/remove/{item}",
+     *     tags={"Cart"},
+     *     summary="Retirer un article du panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="item", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Article supprimé")
+     * )
+     */
+    public function remove(CartItem $item): JsonResponse
+    {
+        $this->cartService->remove($item);
+        return ApiService::response(['message' => 'Item removed'], 200);
+    }
+}

--- a/app/Http/Requests/UpdateCartItemRequest.php
+++ b/app/Http/Requests/UpdateCartItemRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class StoreCartItemRequest extends FormRequest
+class UpdateCartItemRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -23,8 +23,7 @@ class StoreCartItemRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'product_id' => 'required|exists:products,id',
             'quantity' => 'required|integer|min:1',
         ];
-    }    
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Api\{
     ProductController,
     OrderController,
     OrderItemController,
+    CartController,
     PaymentController,
     StripeWebhookController
 };
@@ -190,6 +191,13 @@ Route::prefix('v1')->group(function () {
             Route::delete('/{id}', [ProviderServiceController::class, 'destroy']);
             Route::get('/by-provider/{provider_id}', [ProviderServiceController::class, 'getByProvider']);
             Route::get('/by-service/{service_id}', [ProviderServiceController::class, 'getByService']);
+        });
+
+        Route::prefix('cart')->group(function () {
+            Route::post('/add', [CartController::class, 'add']);
+            Route::delete('/remove/{item}', [CartController::class, 'remove']);
+            Route::put('/update/{item}', [CartController::class, 'update']);
+            Route::get('/', [CartController::class, 'index']);
         });
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `CartController` with basic cart actions
- add `UpdateCartItemRequest`
- enable authorization in `StoreCartItemRequest`
- register cart endpoints in `routes/api.php`

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da860fd408333913aebba884f7b1a