### PR TITLE
Add order shipping status update

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\OrderResource;
+use App\Http\Requests\UpdateOrderStatusRequest;
 use App\Services\ApiService;
 use App\Services\OrderService;
 use App\Models\Order;
@@ -32,6 +33,17 @@ class OrderController extends Controller
             return ApiService::response(new OrderResource($order), 200);
         } catch (\Throwable $e) {
             return ApiService::response('Order not found', 404);
+        }
+    }
+
+    public function updateStatus(UpdateOrderStatusRequest $request, Order $order): JsonResponse
+    {
+        try {
+            $this->authorize('update', $order);
+            $order = $this->orderService->updateShippingStatus($order, $request->shipping_status);
+            return ApiService::response(new OrderResource($order), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
         }
     }
 }

--- a/app/Http/Requests/UpdateOrderStatusRequest.php
+++ b/app/Http/Requests/UpdateOrderStatusRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateOrderStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'shipping_status' => 'required|in:pending,shipped,delivered,cancelled',
+        ];
+    }
+}

--- a/app/Policies/OrderPolicy.php
+++ b/app/Policies/OrderPolicy.php
@@ -26,4 +26,13 @@ class OrderPolicy
 
         return false;
     }
+
+    public function update(User $user, Order $order): bool
+    {
+        if ($user->can('edit_any_order')) {
+            return true;
+        }
+
+        return $order->store && $order->store->user_id === $user->id;
+    }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -83,4 +83,12 @@ class OrderService
 
         abort(403, 'Unauthorized');
     }
+
+    public function updateShippingStatus(Order $order, string $status): Order
+    {
+        $order->shipping_status = $status;
+        $order->save();
+
+        return $order;
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -96,6 +96,7 @@ Route::prefix('v1')->group(function () {
             Route::get('/', [OrderController::class, 'index']);
             Route::get('/{id}', [OrderController::class, 'show']);
             Route::get('/{order}/items', [OrderItemController::class, 'index']);
+            Route::patch('/{order}/status', [OrderController::class, 'updateStatus']);
         });
 
         Route::get('order-items/{id}', [OrderItemController::class, 'show']);

--- a/tests/Feature/Requests/UpdateOrderStatusRequestTest.php
+++ b/tests/Feature/Requests/UpdateOrderStatusRequestTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature\Requests;
+
+use App\Http\Requests\UpdateOrderStatusRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class UpdateOrderStatusRequestTest extends TestCase
+{
+    public function test_update_order_status_request_passes_validation(): void
+    {
+        $data = ['shipping_status' => 'shipped'];
+
+        $request = new UpdateOrderStatusRequest();
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary
- allow providers or admins to update orders
- add controller endpoint to patch shipping status
- validate incoming status values
- test request validation

## Testing
- `vendor/bin/phpunit --filter UpdateOrderStatusRequestTest --stop-on-failure` *(fails: PHPUnit requires dom/xml extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685da86b26d483339e7f2192653158e3