### PR TITLE
Implement cart and checkout APIs

### DIFF
--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CartResource;
+use App\Services\CartService;
+use App\Models\CartItem;
+use App\Services\ApiService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * @OA\Tag(name="Cart", description="Gestion du panier")
+ */
+class CartController extends Controller
+{
+    public function __construct(private CartService $cartService) {}
+
+    /**
+     * @OA\Get(
+     *     path="/cart",
+     *     tags={"Cart"},
+     *     summary="Liste des items du panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Liste du panier")
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        $this->authorize('viewAny', CartItem::class);
+        $items = CartItem::with('product')->where('user_id', Auth::id())->get();
+        return ApiService::response(CartResource::collection($items), 200);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/cart",
+     *     tags={"Cart"},
+     *     summary="Ajouter au panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(@OA\JsonContent(
+     *         required={"product_id","quantity"},
+     *         @OA\Property(property="product_id", type="integer"),
+     *         @OA\Property(property="quantity", type="integer")
+     *     )),
+     *     @OA\Response(response=201, description="Ajouté")
+     * )
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorize('create', CartItem::class);
+        $data = $request->validate([
+            'product_id' => 'required|exists:products,id',
+            'quantity' => 'required|integer|min:1'
+        ]);
+        $item = $this->cartService->addToCart($data);
+        return ApiService::response(new CartResource($item), 201);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/cart/{id}",
+     *     tags={"Cart"},
+     *     summary="Retirer un item",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Supprimé")
+     * )
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $item = CartItem::findOrFail($id);
+        $this->authorize('delete', $item);
+        $this->cartService->remove($item);
+        return ApiService::response(['message' => 'Deleted'], 200);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/cart",
+     *     tags={"Cart"},
+     *     summary="Vider le panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Panier vidé")
+     * )
+     */
+    public function clear(): JsonResponse
+    {
+        $this->authorize('delete', CartItem::class);
+        $this->cartService->clear();
+        return ApiService::response(['message' => 'Cleared'], 200);
+    }
+}

--- a/app/Http/Controllers/Api/CheckoutController.php
+++ b/app/Http/Controllers/Api/CheckoutController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\OrderResource;
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Services\ApiService;
+use App\Services\CartService;
+use App\Services\OrderService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Checkout", description="Finaliser la commande")
+ */
+class CheckoutController extends Controller
+{
+    public function __construct(private OrderService $orderService, private CartService $cartService) {}
+
+    /**
+     * @OA\Post(
+     *     path="/checkout",
+     *     tags={"Checkout"},
+     *     summary="Créer une commande depuis le panier",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(@OA\JsonContent(
+     *         @OA\Property(property="shipping_address", type="string"),
+     *         @OA\Property(property="billing_address", type="string")
+     *     )),
+     *     @OA\Response(response=201, description="Commande créée")
+     * )
+     */
+    public function checkout(Request $request): JsonResponse
+    {
+        $this->authorize('create', Order::class);
+
+        $cartItems = CartItem::with('product')->where('user_id', Auth::id())->get();
+        if ($cartItems->isEmpty()) {
+            return ApiService::response('Cart is empty', 400);
+        }
+
+        $data = [
+            'items' => $cartItems->map(fn($i) => [
+                'product_id' => $i->product_id,
+                'quantity' => $i->quantity,
+                'unit_price' => $i->product->price,
+            ])->toArray(),
+            'shipping_address' => $request->input('shipping_address'),
+            'billing_address' => $request->input('billing_address'),
+        ];
+
+        $order = $this->orderService->create($data);
+        $this->cartService->clear();
+
+        return ApiService::response(new OrderResource($order), 201);
+    }
+}

--- a/app/Http/Controllers/Api/ShippingStatusController.php
+++ b/app/Http/Controllers/Api/ShippingStatusController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\OrderResource;
+use App\Models\Order;
+use App\Services\ApiService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Shipping", description="Mise à jour du statut d'expédition")
+ */
+class ShippingStatusController extends Controller
+{
+    /**
+     * @OA\Patch(
+     *     path="/orders/{order}/shipping-status",
+     *     tags={"Shipping"},
+     *     summary="Mettre à jour le statut d'expédition",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="order", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(@OA\JsonContent(
+     *         required={"shipping_status"},
+     *         @OA\Property(property="shipping_status", type="string")
+     *     )),
+     *     @OA\Response(response=200, description="Statut mis à jour")
+     * )
+     */
+    public function update(Request $request, Order $order): JsonResponse
+    {
+        $this->authorize('update', $order);
+        $data = $request->validate([
+            'shipping_status' => 'required|string'
+        ]);
+        $order->shipping_status = $data['shipping_status'];
+        $order->save();
+
+        return ApiService::response(new OrderResource($order), 200);
+    }
+}

--- a/app/Policies/CartItemPolicy.php
+++ b/app/Policies/CartItemPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CartItem;
+use App\Models\User;
+
+class CartItemPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, CartItem $item): bool
+    {
+        return $item->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, CartItem $item): bool
+    {
+        return $item->user_id === $user->id;
+    }
+
+    public function delete(User $user, CartItem $item): bool
+    {
+        return $item->user_id === $user->id;
+    }
+}

--- a/app/Policies/OrderPolicy.php
+++ b/app/Policies/OrderPolicy.php
@@ -26,4 +26,26 @@ class OrderPolicy
 
         return false;
     }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_order');
+    }
+
+    public function update(User $user, Order $order): bool
+    {
+        if ($user->can('edit_any_order')) {
+            return true;
+        }
+
+        if ($user->can('edit_own_order')) {
+            if ($order->user_id === $user->id) {
+                return true;
+            }
+
+            return $order->store && $order->store->user_id === $user->id;
+        }
+
+        return false;
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,6 +13,7 @@ use App\Models\Review;
 use App\Models\ProviderService;
 use App\Models\Store;
 use App\Models\Order;
+use App\Models\CartItem;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Gate;
@@ -30,6 +31,7 @@ use App\Policies\ProviderServicePolicy;
 use App\Policies\StorePolicy;
 use App\Policies\OrderPolicy;
 use App\Policies\UserPolicy;
+use App\Policies\CartItemPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -51,6 +53,7 @@ class AuthServiceProvider extends ServiceProvider
         ProviderService::class => ProviderServicePolicy::class,
         Store::class           => StorePolicy::class,
         Order::class           => OrderPolicy::class,
+        CartItem::class        => CartItemPolicy::class,
         User::class            => UserPolicy::class,
     ];
 

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -80,7 +80,7 @@ class RolePermissionSeeder extends Seeder
                 self::permissionsByAction(['view_own', 'edit_own'], ['booking']),
                 self::permissionsByAction(['view_own'], ['review']),
                 self::permissionsByAction(['view_own', 'create', 'edit_own', 'delete_own'], ['store', 'product']),
-                self::permissionsByAction(['view_own'], ['order'])
+                self::permissionsByAction(['view_own', 'edit_own'], ['order'])
             ),
 
             'user' => array_merge(

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,9 @@ use App\Http\Controllers\Api\{
     ProductController,
     OrderController,
     OrderItemController,
+    CartController,
+    CheckoutController,
+    ShippingStatusController,
     PaymentController,
     StripeWebhookController
 };
@@ -191,6 +194,16 @@ Route::prefix('v1')->group(function () {
             Route::get('/by-provider/{provider_id}', [ProviderServiceController::class, 'getByProvider']);
             Route::get('/by-service/{service_id}', [ProviderServiceController::class, 'getByService']);
         });
+
+        Route::prefix('cart')->group(function () {
+            Route::get('/', [CartController::class, 'index']);
+            Route::post('/', [CartController::class, 'store']);
+            Route::delete('/', [CartController::class, 'clear']);
+            Route::delete('/{id}', [CartController::class, 'destroy']);
+        });
+
+        Route::post('/checkout', [CheckoutController::class, 'checkout']);
+        Route::patch('/orders/{order}/shipping-status', [ShippingStatusController::class, 'update']);
         /*
         |--------------------------------------------------------------------------
         |  Payment


### PR DESCRIPTION
## Summary
- add CartItem policy and link it in auth provider
- create CartController for cart management
- create CheckoutController to convert cart to order
- create ShippingStatusController to update shipping status
- assign `edit_own_order` permission to providers
- enhance Order policy with create/update rules
- document new routes and wire them in API routes

## Testing
- `composer install --no-scripts --ignore-platform-req=ext-gd --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `./vendor/bin/phpunit` *(fails: PHPUnit requires missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_685da86fdf0883338686d5129a9bf624