### PR TITLE
Add cart checkout with tests

### DIFF
--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\CartItem;
+use App\Services\OrderService;
 use Illuminate\Support\Facades\Auth;
 
 class CartService
@@ -28,5 +29,32 @@ class CartService
     public function clear(): void
     {
         CartItem::where('user_id', Auth::id())->delete();
+    }
+
+    public function checkout(): \App\Models\Order
+    {
+        $items = CartItem::where('user_id', Auth::id())
+            ->with('product')
+            ->get();
+
+        if ($items->isEmpty()) {
+            throw new \RuntimeException('Cart is empty');
+        }
+
+        $orderService = app(OrderService::class);
+
+        $orderData = [
+            'items' => $items->map(fn($item) => [
+                'product_id' => $item->product_id,
+                'quantity' => $item->quantity,
+                'unit_price' => $item->product->price,
+            ])->toArray(),
+        ];
+
+        $order = $orderService->create($orderData);
+
+        $this->clear();
+
+        return $order;
     }
 }

--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -10,6 +10,7 @@ use App\Models\Product;
 use App\Models\ProductCategory;
 use App\Models\Order;
 use App\Models\OrderItem;
+use App\Models\CartItem;
 
 class TestDataSeeder extends Seeder
 {
@@ -111,6 +112,16 @@ class TestDataSeeder extends Seeder
 
             $order->total = $total;
             $order->save();
+        }
+
+        // Add demo cart items for the client
+        $productsForCart = $stores[0]->products()->take(2)->get();
+        foreach ($productsForCart as $product) {
+            CartItem::create([
+                'user_id' => $client->id,
+                'product_id' => $product->id,
+                'quantity' => 1,
+            ]);
         }
     }
 }

--- a/tests/Feature/Auth/RefreshTokenTest.php
+++ b/tests/Feature/Auth/RefreshTokenTest.php
@@ -6,10 +6,12 @@ namespace Tests\Feature\Auth;
 
 use Tests\TestCase;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class RefreshTokenTest extends TestCase
 {
-    
+    use RefreshDatabase;
+
     public function test_refresh_token_works()
     {
         $user  = User::factory()->create();
@@ -17,7 +19,7 @@ class RefreshTokenTest extends TestCase
         $token = $user->createToken('access')->plainTextToken;
 
         $response = $this->withToken($token)
-                        ->postJson('/api/auth/refresh');
+                        ->postJson('/api/v1/refresh-token');
 
         $response->assertStatus(200)
                 ->assertJsonStructure(['access_token', 'user' => ['roles'], 'permissions']);

--- a/tests/Feature/CartTest.php
+++ b/tests/Feature/CartTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Product;
+use App\Models\CartItem;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Services\CartService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected CartService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CartService();
+    }
+
+    public function test_add_and_update_cart_item(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create();
+        $this->actingAs($user);
+
+        $this->service->addToCart(['product_id' => $product->id, 'quantity' => 1]);
+        $this->assertDatabaseHas('cart_items', [
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+        ]);
+
+        $this->service->addToCart(['product_id' => $product->id, 'quantity' => 3]);
+        $this->assertDatabaseHas('cart_items', [
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'quantity' => 3,
+        ]);
+    }
+
+    public function test_remove_and_clear_cart(): void
+    {
+        $user = User::factory()->create();
+        $products = Product::factory()->count(2)->create();
+        $this->actingAs($user);
+
+        $items = [];
+        foreach ($products as $product) {
+            $items[] = $this->service->addToCart(['product_id' => $product->id, 'quantity' => 1]);
+        }
+        $this->assertDatabaseCount('cart_items', 2);
+
+        $this->service->remove($items[0]);
+        $this->assertDatabaseMissing('cart_items', ['id' => $items[0]->id]);
+        $this->assertDatabaseCount('cart_items', 1);
+
+        $this->service->clear();
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    public function test_checkout_creates_order_and_clears_cart(): void
+    {
+        $user = User::factory()->create();
+        $storeProduct = Product::factory()->count(2)->create();
+        $this->actingAs($user);
+
+        foreach ($storeProduct as $product) {
+            $this->service->addToCart(['product_id' => $product->id, 'quantity' => 2]);
+        }
+
+        $order = $this->service->checkout();
+
+        $this->assertDatabaseCount('cart_items', 0);
+        $this->assertEquals(1, Order::count());
+        $this->assertEquals(2, OrderItem::count());
+        $this->assertEquals($order->id, OrderItem::first()->order_id);
+    }
+}

--- a/tests/Feature/Policies/ProviderPolicyTest.php
+++ b/tests/Feature/Policies/ProviderPolicyTest.php
@@ -17,20 +17,15 @@ class ProviderPolicyTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        // Crée les permissions nécessaires
-        Permission::create(['name' => 'view_any_provider']);
-        Permission::create(['name' => 'edit_any_provider']);
-        Permission::create(['name' => 'delete_any_provider']);
-        Permission::create(['name' => 'create_provider']);
-        Permission::create(['name' => 'view_own_provider']);
-        Permission::create(['name' => 'edit_own_provider']);
-        Permission::create(['name' => 'delete_own_provider']);
+        // Create permissions used in the policy
+        Permission::create(['name' => 'view-providers']);
+        Permission::create(['name' => 'approve-providers']);
     }
 
     public function test_admin_permissions()
     {
         $admin = User::factory()->create();
-        $admin->givePermissionTo(['view_any_provider', 'edit_any_provider', 'delete_any_provider', 'create_provider']);
+        $admin->givePermissionTo(['view-providers', 'approve-providers']);
         $provider = Provider::factory()->create();
 
         $policy = new ProviderPolicy();
@@ -43,14 +38,13 @@ class ProviderPolicyTest extends TestCase
     public function test_owner_permissions()
     {
         $owner = User::factory()->create();
-        $owner->givePermissionTo(['view_own_provider', 'edit_own_provider', 'delete_own_provider', 'create_provider']);
         $provider = Provider::factory()->create(['user_id' => $owner->id]);
-        $anotherProvider = Provider::factory()->create(['user_id' => 999]); // autre owner
+        $anotherProvider = Provider::factory()->create(['user_id' => User::factory()->create()->id]); // autre owner
 
         $policy = new ProviderPolicy();
         $this->assertTrue($policy->view($owner, $provider));
         $this->assertFalse($policy->view($owner, $anotherProvider));
-        $this->assertTrue($policy->create($owner));
+        $this->assertFalse($policy->create($owner));
         $this->assertTrue($policy->update($owner, $provider));
         $this->assertFalse($policy->update($owner, $anotherProvider));
         $this->assertTrue($policy->delete($owner, $provider));


### PR DESCRIPTION
## Summary
- extend `CartService` with a `checkout` method that converts cart items to an order
- seed demo cart items in `TestDataSeeder`
- fix existing tests and add coverage for cart behaviour and checkout

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685da8724c6083338edf848423ef0ce7