### PR TITLE
Update cart queries to use cart_id

### DIFF
--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -57,7 +57,9 @@ class CartService
 
     public function checkout(): \App\Models\Order
     {
-        $items = CartItem::where('user_id', Auth::id())
+        $cart = $this->getUserCart();
+
+        $items = $cart->items()
             ->with('product')
             ->get();
 

--- a/tests/Feature/CartTest.php
+++ b/tests/Feature/CartTest.php
@@ -30,15 +30,16 @@ class CartTest extends TestCase
         $this->actingAs($user);
 
         $this->service->addToCart(['product_id' => $product->id, 'quantity' => 1]);
+        $cartId = $this->service->getUserCart()->id;
         $this->assertDatabaseHas('cart_items', [
-            'user_id' => $user->id,
+            'cart_id' => $cartId,
             'product_id' => $product->id,
             'quantity' => 1,
         ]);
 
         $this->service->addToCart(['product_id' => $product->id, 'quantity' => 3]);
         $this->assertDatabaseHas('cart_items', [
-            'user_id' => $user->id,
+            'cart_id' => $cartId,
             'product_id' => $product->id,
             'quantity' => 3,
         ]);


### PR DESCRIPTION
## Summary
- fetch cart items by `cart_id` in `CartService::checkout`
- update cart feature test to assert on `cart_id`

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685db3ae83908333aeeb1e25ace98d76