### PR TITLE
Fix cart logic and add Product policy

### DIFF
--- a/app/Http/Controllers/Api/CartController.php
+++ b/app/Http/Controllers/Api/CartController.php
@@ -31,7 +31,7 @@ class CartController extends Controller
     public function index(): JsonResponse
     {
         $this->authorize('viewAny', CartItem::class);
-        $items = CartItem::with('product')->where('user_id', Auth::id())->get();
+        $items = $this->cartService->listItems();
         return ApiService::response(CartResource::collection($items), 200);
     }
 

--- a/app/Policies/CartItemPolicy.php
+++ b/app/Policies/CartItemPolicy.php
@@ -14,7 +14,7 @@ class CartItemPolicy
 
     public function view(User $user, CartItem $item): bool
     {
-        return $item->user_id === $user->id;
+        return optional($item->cart)->user_id === $user->id;
     }
 
     public function create(User $user): bool
@@ -24,11 +24,11 @@ class CartItemPolicy
 
     public function update(User $user, CartItem $item): bool
     {
-        return $item->user_id === $user->id;
+        return optional($item->cart)->user_id === $user->id;
     }
 
     public function delete(User $user, CartItem $item): bool
     {
-        return $item->user_id === $user->id;
+        return optional($item->cart)->user_id === $user->id;
     }
 }

--- a/app/Policies/ProductPolicy.php
+++ b/app/Policies/ProductPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Product;
+use App\Models\User;
+
+class ProductPolicy
+{
+    public function view(User $user, Product $product): bool
+    {
+        if ($user->can('view_any_product')) {
+            return true;
+        }
+
+        if (!$product->exists) {
+            return $user->can('view_own_product');
+        }
+
+        return $user->can('view_own_product') && optional($product->store)->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_product');
+    }
+
+    public function update(User $user, Product $product): bool
+    {
+        if ($user->can('edit_any_product')) {
+            return true;
+        }
+
+        return $user->can('edit_own_product') && optional($product->store)->user_id === $user->id;
+    }
+
+    public function delete(User $user, Product $product): bool
+    {
+        if ($user->can('delete_any_product')) {
+            return true;
+        }
+
+        return $user->can('delete_own_product') && optional($product->store)->user_id === $user->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,6 +14,7 @@ use App\Models\ProviderService;
 use App\Models\Store;
 use App\Models\Order;
 use App\Models\CartItem;
+use App\Models\Product;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Gate;
@@ -32,6 +33,7 @@ use App\Policies\StorePolicy;
 use App\Policies\OrderPolicy;
 use App\Policies\UserPolicy;
 use App\Policies\CartItemPolicy;
+use App\Policies\ProductPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -52,6 +54,7 @@ class AuthServiceProvider extends ServiceProvider
         Review::class          => ReviewPolicy::class,
         ProviderService::class => ProviderServicePolicy::class,
         Store::class           => StorePolicy::class,
+        Product::class         => ProductPolicy::class,
         Order::class           => OrderPolicy::class,
         CartItem::class        => CartItemPolicy::class,
         User::class            => UserPolicy::class,

--- a/app/Services/CartService.php
+++ b/app/Services/CartService.php
@@ -55,7 +55,7 @@ class CartService
         return $cart->items()->with('product')->get();
     }
 
-    public function checkout(): \App\Models\Order
+    public function checkout(?string $shippingAddress = null, ?string $billingAddress = null): \App\Models\Order
     {
         $cart = $this->getUserCart();
 
@@ -75,6 +75,8 @@ class CartService
                 'quantity' => $item->quantity,
                 'unit_price' => $item->product->price,
             ])->toArray(),
+            'shipping_address' => $shippingAddress,
+            'billing_address' => $billingAddress,
         ];
 
         $order = $orderService->create($orderData);

--- a/tests/Feature/CartTest.php
+++ b/tests/Feature/CartTest.php
@@ -75,7 +75,10 @@ class CartTest extends TestCase
             $this->service->addToCart(['product_id' => $product->id, 'quantity' => 2]);
         }
 
-        $order = $this->service->checkout();
+        $order = $this->service->checkout('addr1', 'addr2');
+
+        $this->assertEquals('addr1', $order->shipping_address);
+        $this->assertEquals('addr2', $order->billing_address);
 
         $this->assertDatabaseCount('cart_items', 0);
         $this->assertEquals(1, Order::count());

--- a/tests/Feature/Policies/ProductPolicyTest.php
+++ b/tests/Feature/Policies/ProductPolicyTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Policies;
+
+use App\Models\User;
+use App\Models\Product;
+use App\Models\Store;
+use App\Policies\ProductPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class ProductPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::create(['name' => 'view_any_product']);
+        Permission::create(['name' => 'view_own_product']);
+        Permission::create(['name' => 'create_product']);
+        Permission::create(['name' => 'edit_any_product']);
+        Permission::create(['name' => 'edit_own_product']);
+        Permission::create(['name' => 'delete_any_product']);
+        Permission::create(['name' => 'delete_own_product']);
+    }
+
+    public function test_admin_permissions()
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo(['view_any_product', 'create_product', 'edit_any_product', 'delete_any_product']);
+        $store = Store::factory()->create(['user_id' => $admin->id]);
+        $product = Product::factory()->create(['store_id' => $store->id]);
+
+        $policy = new ProductPolicy();
+        $this->assertTrue($policy->view($admin, $product));
+        $this->assertTrue($policy->create($admin));
+        $this->assertTrue($policy->update($admin, $product));
+        $this->assertTrue($policy->delete($admin, $product));
+    }
+
+    public function test_owner_permissions()
+    {
+        $owner = User::factory()->create();
+        $store = Store::factory()->create(['user_id' => $owner->id]);
+        $product = Product::factory()->create(['store_id' => $store->id]);
+        $otherProduct = Product::factory()->create();
+        $owner->givePermissionTo(['view_own_product', 'edit_own_product', 'delete_own_product']);
+
+        $policy = new ProductPolicy();
+        $this->assertTrue($policy->view($owner, $product));
+        $this->assertFalse($policy->view($owner, $otherProduct));
+        $this->assertFalse($policy->create($owner));
+        $this->assertTrue($policy->update($owner, $product));
+        $this->assertFalse($policy->update($owner, $otherProduct));
+        $this->assertTrue($policy->delete($owner, $product));
+        $this->assertFalse($policy->delete($owner, $otherProduct));
+    }
+
+    public function test_guest_permissions()
+    {
+        $guest = User::factory()->create();
+        $product = Product::factory()->create();
+
+        $policy = new ProductPolicy();
+        $this->assertFalse($policy->view($guest, $product));
+        $this->assertFalse($policy->create($guest));
+        $this->assertFalse($policy->update($guest, $product));
+        $this->assertFalse($policy->delete($guest, $product));
+    }
+}


### PR DESCRIPTION
## Summary
- fix cart controller to use cart service
- clean up checkout controller and use service checkout method
- update cart service checkout to accept addresses
- update cart item policy to reference cart relation
- add product policy and tests
- register product policy in auth service provider
- adjust cart tests for new checkout params

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: vendor binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e899975288333ba69ab857ad4df45