### PR TITLE
Assign default user role

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -103,7 +103,9 @@ class AuthController extends Controller
  public function register(StoreUserRequest $request, UserService $userService)
  {
      try {
-         $user = $userService->createUser($request->validated());
+        $user = $userService->createUser($request->validated());
+        // Attribuer le rôle "user" par défaut lors de l'inscription
+        $user->assignRole('user');
  
          // Générer un token
          $token = $user->createToken('mypetly')->plainTextToken;


### PR DESCRIPTION
## Summary
- assign `user` role automatically when a new user registers

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68692834193483339b4676f9e3d2941e