### PR TITLE
Fix CategoryPolicy permissions

### DIFF
--- a/app/Policies/CategoryPolicy.php
+++ b/app/Policies/CategoryPolicy.php
@@ -9,23 +9,23 @@ class CategoryPolicy
 {
     public function view(User $user, Category $category): bool
     {
-        return $user->can('view-services');
+        return $user->can('view_any_category');
 
     }
 
     public function create(User $user): bool
     {
-        return $user->can('create-services');
+        return $user->can('create_category');
     }
 
     public function update(User $user, Category $category): bool
     {
-        return $user->can('edit-services');
+        return $user->can('edit_any_category');
 
     }
 
     public function delete(User $user, Category $category): bool
     {
-        return $user->can('delete-services');
+        return $user->can('delete_any_category');
     }
 }


### PR DESCRIPTION
## Summary
- use the correct category-related permissions in `CategoryPolicy`

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a73ec98bc83339893facd30ee8798