### PR TITLE
Fix service icon update

### DIFF
--- a/app/Http/Requests/StoreServiceRequest.php
+++ b/app/Http/Requests/StoreServiceRequest.php
@@ -21,6 +21,8 @@ class StoreServiceRequest extends FormRequest
         'name.*'       => 'required|string|max:255', // Chaque langue doit être une string
         'description'  => 'nullable|array',
         'description.*'=> 'nullable|string',
+        'icon'         => 'nullable|string|max:255',
+        'color'        => 'nullable|string|max:7',
         'price'        => 'required|numeric|min:0',
         'active'       => 'boolean',
     ];

--- a/app/Http/Requests/UpdateServiceRequest.php
+++ b/app/Http/Requests/UpdateServiceRequest.php
@@ -20,6 +20,8 @@ class UpdateServiceRequest extends FormRequest
         'name.*'       => 'sometimes|string|max:255',
         'description'  => 'nullable|array',
         'description.*'=> 'nullable|string',
+        'icon'         => 'sometimes|nullable|string|max:255',
+        'color'        => 'sometimes|nullable|string|max:7',
         'price'        => 'sometimes|numeric|min:0',
         'active'       => 'sometimes|boolean',
     ];

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -12,7 +12,16 @@ class Service extends Model
 {
     use HasFactory, HasTranslations;
 
-    protected $fillable = ['name', 'description', 'price', 'active', 'provider_id', 'category_id'];
+    protected $fillable = [
+        'name',
+        'description',
+        'price',
+        'active',
+        'icon',
+        'color',
+        'provider_id',
+        'category_id',
+    ];
     public $translatable = ['name', 'description'];
 
     public function category()

--- a/app/Services/ServiceService.php
+++ b/app/Services/ServiceService.php
@@ -24,6 +24,8 @@ class ServiceService
         $service->provider_id = $data['provider_id'];
         $service->price = $data['price'];
         $service->active = $data['active'] ?? true;
+        $service->icon = $data['icon'] ?? null;
+        $service->color = $data['color'] ?? null;
 
         // Gérer les traductions
         $service->setTranslations('name', $data['name']);
@@ -46,6 +48,12 @@ class ServiceService
         }
         if (isset($data['active'])) {
             $service->active = $data['active'];
+        }
+        if (isset($data['icon'])) {
+            $service->icon = $data['icon'];
+        }
+        if (array_key_exists('color', $data)) {
+            $service->color = $data['color'];
         }
 
         // Mise à jour des traductions

--- a/tests/Feature/Requests/ServiceRequestTest.php
+++ b/tests/Feature/Requests/ServiceRequestTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Requests;
+
+use App\Http\Requests\StoreServiceRequest;
+use App\Http\Requests\UpdateServiceRequest;
+use App\Models\Category;
+use App\Models\Provider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class ServiceRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_service_request_passes_validation_when_authorized(): void
+    {
+        $category = Category::create([
+            'name'  => ['en' => 'Vet'],
+            'icon'  => 'icon',
+            'type'  => 'service',
+            'color' => '#ffffff',
+        ]);
+        $provider = Provider::factory()->create();
+
+        $data = [
+            'category_id' => $category->id,
+            'provider_id' => $provider->id,
+            'name'        => ['en' => 'Service'],
+            'description' => ['en' => 'Desc'],
+            'icon'        => 'mdi-vet',
+            'color'       => '#ff0000',
+            'price'       => 10,
+            'active'      => true,
+        ];
+
+        $request = new StoreServiceRequest();
+
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+
+    public function test_update_service_request_passes_validation_when_authorized(): void
+    {
+        $category = Category::create([
+            'name'  => ['en' => 'Vet'],
+            'icon'  => 'icon',
+            'type'  => 'service',
+            'color' => '#ffffff',
+        ]);
+        $provider = Provider::factory()->create();
+
+        $data = [
+            'category_id' => $category->id,
+            'provider_id' => $provider->id,
+            'name'        => ['en' => 'Service'],
+            'description' => ['en' => 'Desc'],
+            'icon'        => 'mdi-vet',
+            'color'       => '#00ff00',
+            'price'       => 20,
+            'active'      => false,
+        ];
+
+        $request = new UpdateServiceRequest();
+
+        $this->assertTrue($request->authorize());
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary
- allow icon and color to be mass-assigned on Service model
- persist icon and color in ServiceService
- validate icon and color in StoreServiceRequest and UpdateServiceRequest
- cover new validation rules with ServiceRequestTest

## Testing
- `php -v` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae010da088333b07155a723f20b9b