### PR TITLE
Add tax_code to providers

### DIFF
--- a/app/Http/Controllers/Api/ProviderController.php
+++ b/app/Http/Controllers/Api/ProviderController.php
@@ -56,6 +56,7 @@ class ProviderController extends Controller
      *         ),
      *         @OA\Property(property="email", type="string", example="john@example.com"),
      *         @OA\Property(property="phone", type="string", example="+123456789"),
+     *         @OA\Property(property="tax_code", type="string", example="TX123456"),
      *         @OA\Property(property="address", type="string", example="123 Street, City"),
      *         @OA\Property(property="specialization", type="object",
      *             example={"fr": "Vétérinaire", "en": "Veterinarian", "es": "Veterinario"}
@@ -138,6 +139,7 @@ class ProviderController extends Controller
      *         ),
      *         @OA\Property(property="email", type="string", example="johnupdated@example.com"),
      *         @OA\Property(property="phone", type="string", example="+987654321"),
+     *         @OA\Property(property="tax_code", type="string", example="TX123456"),
      *         @OA\Property(property="address", type="string", example="456 Avenue, City"),
      *         @OA\Property(property="specialization", type="object",
      *             example={"fr": "Grooming", "en": "Grooming", "es": "Peluquería"}

--- a/app/Http/Requests/StoreProviderRequest.php
+++ b/app/Http/Requests/StoreProviderRequest.php
@@ -18,6 +18,7 @@ class StoreProviderRequest extends FormRequest
             'name.*'          => 'required|string|max:255',
             'email'           => 'required|email|unique:providers,email',
             'phone'           => 'nullable|string|max:20',
+            'tax_code'        => 'nullable|string|max:50',
             'address'         => 'nullable|string|max:255',
             'description'     => 'nullable|array',
             'description.*'   => 'nullable|string',

--- a/app/Http/Requests/UpdateProviderRequest.php
+++ b/app/Http/Requests/UpdateProviderRequest.php
@@ -18,6 +18,7 @@ class UpdateProviderRequest extends FormRequest
             'name.*'          => 'sometimes|string|max:255',
             'email'           => 'sometimes|email|unique:providers,email,' . $this->provider,
             'phone'           => 'nullable|string|max:20',
+            'tax_code'        => 'nullable|string|max:50',
             'address'         => 'nullable|string|max:255',
             'description'     => 'nullable|array',
             'description.*'   => 'nullable|string',

--- a/app/Http/Resources/ProviderResource.php
+++ b/app/Http/Resources/ProviderResource.php
@@ -15,6 +15,7 @@ class ProviderResource extends JsonResource
             'name'          => $this->getTranslations('name'),
             'email'         => $this->email,
             'phone'         => $this->phone,
+            'tax_code'      => $this->tax_code,
             'address'       => $this->address,
             'description'   => $this->getTranslations('description'),
             'photo'         => $this->photo,

--- a/app/Models/Provider.php
+++ b/app/Models/Provider.php
@@ -17,6 +17,7 @@ class Provider extends Model
         'name',
         'email',
         'phone',
+        'tax_code',
         'address',
         'description',
         'photo',

--- a/app/Services/ProviderService.php
+++ b/app/Services/ProviderService.php
@@ -22,6 +22,7 @@ class ProviderService
         $provider = new Provider();
         $provider->email = $data['email'];
         $provider->phone = $data['phone'] ?? null;
+        $provider->tax_code = $data['tax_code'] ?? null;
         $provider->address = $data['address'] ?? null;
         $provider->rating = $data['rating'] ?? 0;
 
@@ -40,6 +41,9 @@ class ProviderService
         }
         if (isset($data['phone'])) {
             $provider->phone = $data['phone'];
+        }
+        if (isset($data['tax_code'])) {
+            $provider->tax_code = $data['tax_code'];
         }
         if (isset($data['address'])) {
             $provider->address = $data['address'];

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -17,6 +17,7 @@ class ProviderFactory extends Factory
             'name'      => $this->faker->company,
             'email'     => $this->faker->unique()->companyEmail,
             'phone'     => $this->faker->phoneNumber,
+            'tax_code'  => $this->faker->bothify('??######'),
             'address'   => $this->faker->address,
             // ajoute d’autres champs selon ta table, exemple :
             // 'description' => $this->faker->sentence,

--- a/database/migrations/2025_07_19_083957_add_tax_code_to_providers_table.php
+++ b/database/migrations/2025_07_19_083957_add_tax_code_to_providers_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('providers', function (Blueprint $table) {
+            $table->string('tax_code')->nullable()->after('address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('providers', function (Blueprint $table) {
+            $table->dropColumn('tax_code');
+        });
+    }
+};

--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -55,6 +55,7 @@ class TestDataSeeder extends Seeder
             $provider = Provider::factory()->create([
                 'user_id' => $providerUser->id,
                 'name' => ['en' => "Provider {$i}", 'fr' => "Fournisseur {$i}"],
+                'tax_code' => 'TX' . str_pad($i, 4, '0', STR_PAD_LEFT),
             ]);
 
             // Create store


### PR DESCRIPTION
## Summary
- add `tax_code` column migration
- support `tax_code` in Provider model, service, resource, and validation
- update provider factory and seeder
- document new field in swagger annotations

## Testing
- `composer install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687b5937d23483338dad9efa15598a97