### PR TITLE
Implement provider photo upload

### DIFF
--- a/app/Http/Requests/UploadProviderPhotoRequest.php
+++ b/app/Http/Requests/UploadProviderPhotoRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadProviderPhotoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'photo' => 'required|image|mimes:jpeg,png,jpg|max:5120',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -89,6 +89,7 @@ Route::prefix('v1')->group(function () {
         |--------------------------------------------------------------------------
         */
         Route::get('providers/by-user/{userId}', [ProviderController::class, 'getByUserId']);
+        Route::post('providers/{id}/photo', [ProviderController::class, 'uploadPhoto']);
         Route::apiResource('providers', ProviderController::class);
         Route::apiResource('services', ServiceController::class);
         Route::apiResource('categories', CategoryController::class);

--- a/tests/Feature/ProviderPhotoUploadTest.php
+++ b/tests/Feature/ProviderPhotoUploadTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Provider;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ProviderPhotoUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_provider_photo_upload_successful(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $provider = Provider::factory()->create(['user_id' => $user->id]);
+        $token = $user->createToken('access')->plainTextToken;
+
+        $response = $this->withToken($token)->postJson('/api/v1/providers/' . $provider->id . '/photo', [
+            'photo' => UploadedFile::fake()->image('avatar.jpg'),
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['message', 'photo_url']);
+
+        $provider->refresh();
+        $this->assertNotNull($provider->photo);
+        Storage::disk('public')->assertExists($provider->photo);
+    }
+
+    public function test_provider_photo_upload_validation_error(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $provider = Provider::factory()->create(['user_id' => $user->id]);
+        $token = $user->createToken('access')->plainTextToken;
+
+        $response = $this->withToken($token)->postJson('/api/v1/providers/' . $provider->id . '/photo', [
+            'photo' => UploadedFile::fake()->create('doc.pdf', 10, 'application/pdf'),
+        ]);
+
+        $response->assertStatus(422);
+        Storage::disk('public')->assertMissing('providers/doc.pdf');
+    }
+}


### PR DESCRIPTION
## Summary
- add `UploadProviderPhotoRequest` for validating provider photo uploads
- extend `ProviderController` with `uploadPhoto` endpoint
- support photo files in `ProviderService` including `updatePhoto`
- register route `providers/{id}/photo`
- test provider photo upload and validation

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit --testsuite Feature --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687e39b0badc833386a6d294c0a93114