### PR TITLE
Add product category API endpoints

### DIFF
--- a/app/Http/Controllers/ProductCategoryController.php
+++ b/app/Http/Controllers/ProductCategoryController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ProductCategoryResource;
+use App\Models\ProductCategory;
+use App\Services\ApiService;
+use App\Services\ProductCategoryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProductCategoryController extends Controller
+{
+    public function __construct(private ProductCategoryService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        $this->authorize('view', new ProductCategory());
+        $categories = ProductCategory::all();
+        return ApiService::response(ProductCategoryResource::collection($categories), 200);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorize('create', new ProductCategory());
+        $validated = $request->validate([
+            'name' => 'required|array',
+            'name.*' => 'required|string|max:255',
+            'description' => 'nullable|array',
+            'description.*' => 'nullable|string',
+        ]);
+        $category = $this->service->create($validated);
+        return ApiService::response(new ProductCategoryResource($category), 201);
+    }
+
+    public function show(ProductCategory $productCategory): JsonResponse
+    {
+        $this->authorize('view', $productCategory);
+        return ApiService::response(new ProductCategoryResource($productCategory), 200);
+    }
+
+    public function update(Request $request, ProductCategory $productCategory): JsonResponse
+    {
+        $this->authorize('update', $productCategory);
+        $validated = $request->validate([
+            'name' => 'required|array',
+            'name.*' => 'required|string|max:255',
+            'description' => 'nullable|array',
+            'description.*' => 'nullable|string',
+        ]);
+        $updated = $this->service->update($productCategory, $validated);
+        return ApiService::response(new ProductCategoryResource($updated), 200);
+    }
+
+    public function destroy(ProductCategory $productCategory): JsonResponse
+    {
+        $this->authorize('delete', $productCategory);
+        $this->service->delete($productCategory);
+        return ApiService::response(['message' => 'Product category deleted'], 200);
+    }
+}
+

--- a/app/Policies/ProductCategoryPolicy.php
+++ b/app/Policies/ProductCategoryPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ProductCategory;
+use App\Models\User;
+
+class ProductCategoryPolicy
+{
+    public function view(User $user, ProductCategory $category): bool
+    {
+        return $user->can('view_any_product_category');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_product_category');
+    }
+
+    public function update(User $user, ProductCategory $category): bool
+    {
+        return $user->can('edit_any_product_category');
+    }
+
+    public function delete(User $user, ProductCategory $category): bool
+    {
+        return $user->can('delete_any_product_category');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\Provider;
 use App\Models\Booking;
 use App\Models\Collar;
 use App\Models\Category;
+use App\Models\ProductCategory;
 use App\Models\Review;
 use App\Models\ProviderService;
 use App\Models\Store;
@@ -25,6 +26,7 @@ use App\Policies\ProviderPolicy;
 use App\Policies\BookingPolicy;
 use App\Policies\CollarPolicy;
 use App\Policies\CategoryPolicy;
+use App\Policies\ProductCategoryPolicy;
 use App\Policies\RolePolicy;
 use App\Policies\PermissionPolicy;
 use App\Policies\ReviewPolicy;
@@ -49,6 +51,7 @@ class AuthServiceProvider extends ServiceProvider
         Booking::class         => BookingPolicy::class,
         Collar::class          => CollarPolicy::class,
         Category::class        => CategoryPolicy::class,
+        ProductCategory::class => ProductCategoryPolicy::class,
         Role::class            => RolePolicy::class,
         Permission::class      => PermissionPolicy::class,
         Review::class          => ReviewPolicy::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\Api\{
     PaymentController,
     StripeWebhookController
 };
+use App\Http\Controllers\ProductCategoryController;
 
 
 Route::prefix('v1')->group(function () {
@@ -95,6 +96,7 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('categories', CategoryController::class);
         Route::apiResource('stores', StoreController::class);
         Route::apiResource('products', ProductController::class);
+        Route::apiResource('product-categories', ProductCategoryController::class);
 
         Route::prefix('orders')->group(function () {
             Route::get('/', [OrderController::class, 'index']);

--- a/tests/Feature/ProductCategoryTest.php
+++ b/tests/Feature/ProductCategoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class ProductCategoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $permissions = [
+        'view_any_product_category',
+        'create_product_category',
+        'edit_any_product_category',
+        'delete_any_product_category',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach ($this->permissions as $perm) {
+            Permission::create(['name' => $perm]);
+        }
+    }
+
+    public function test_product_category_crud_endpoints(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($this->permissions);
+        Sanctum::actingAs($user);
+
+        $createData = [
+            'name' => ['en' => 'Food'],
+            'description' => ['en' => 'desc'],
+        ];
+
+        $response = $this->postJson('/api/v1/product-categories', $createData);
+        $response->assertStatus(201)->assertJsonPath('name.en', 'Food');
+        $categoryId = $response->json('id');
+
+        $this->getJson('/api/v1/product-categories')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $categoryId]);
+
+        $this->getJson("/api/v1/product-categories/{$categoryId}")
+            ->assertStatus(200)
+            ->assertJsonPath('id', $categoryId);
+
+        $updateData = [
+            'name' => ['en' => 'Updated'],
+            'description' => ['en' => 'updated'],
+        ];
+
+        $this->putJson("/api/v1/product-categories/{$categoryId}", $updateData)
+            ->assertStatus(200)
+            ->assertJsonPath('name.en', 'Updated');
+
+        $this->deleteJson("/api/v1/product-categories/{$categoryId}")
+            ->assertStatus(200);
+
+        $this->assertDatabaseMissing('product_categories', ['id' => $categoryId]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `ProductCategoryController` CRUD using service and resource
- secure product category API with dedicated policy and registration
- add API resource route and tests for product category operations

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6891e8d25edc8333a713d825890e7773