### PR TITLE
Allow authorized users to manage product categories

### DIFF
--- a/app/Http/Requests/StoreProductCategoryRequest.php
+++ b/app/Http/Requests/StoreProductCategoryRequest.php
@@ -11,7 +11,7 @@ class StoreProductCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return auth()->user()?->can('manage product categories') ?? false;
     }
 
     /**

--- a/app/Http/Requests/UpdateProductCategoryRequest.php
+++ b/app/Http/Requests/UpdateProductCategoryRequest.php
@@ -11,7 +11,7 @@ class UpdateProductCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return auth()->user()?->can('manage product categories') ?? false;
     }
 
     /**

--- a/tests/Feature/Requests/ProductCategoryRequestTest.php
+++ b/tests/Feature/Requests/ProductCategoryRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Requests;
+
+use App\Http\Requests\StoreProductCategoryRequest;
+use App\Http\Requests\UpdateProductCategoryRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Validator;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class ProductCategoryRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::create(['name' => 'manage product categories']);
+    }
+
+    public function test_store_product_category_request_authorizes_when_user_has_permission(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('manage product categories');
+        $this->actingAs($user);
+
+        $request = new StoreProductCategoryRequest();
+
+        $this->assertTrue($request->authorize());
+
+        $data = [
+            'name' => ['en' => 'Category'],
+            'description' => ['en' => 'Desc'],
+        ];
+
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+
+    public function test_update_product_category_request_authorizes_when_user_has_permission(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('manage product categories');
+        $this->actingAs($user);
+
+        $request = new UpdateProductCategoryRequest();
+
+        $this->assertTrue($request->authorize());
+
+        $data = [
+            'name' => ['en' => 'Category'],
+            'description' => ['en' => 'Desc'],
+        ];
+
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->passes());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Check `manage product categories` permission in `StoreProductCategoryRequest` and `UpdateProductCategoryRequest`
- Add feature tests confirming authorized users may create or update product categories

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6891e8e220c48333930dbe3d4f27d6d6