### PR TITLE
Move ProductCategoryController to API namespace

### DIFF
--- a/app/Http/Controllers/Api/ProductCategoryController.php
+++ b/app/Http/Controllers/Api/ProductCategoryController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api;
 
+use App\Http\Controllers\Controller;
 use App\Http\Resources\ProductCategoryResource;
 use App\Models\ProductCategory;
 use App\Services\ApiService;

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,7 +25,7 @@ use App\Http\Controllers\Api\{
     PaymentController,
     StripeWebhookController
 };
-use App\Http\Controllers\ProductCategoryController;
+use App\Http\Controllers\Api\ProductCategoryController;
 
 
 Route::prefix('v1')->group(function () {


### PR DESCRIPTION
## Summary
- move `ProductCategoryController` into `App\Http\Controllers\Api`
- import controller from `Api` namespace in `routes/api.php`

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6891fcb13b108333a13413b530f14240