### PR TITLE
Use FormRequest for product category endpoints

### DIFF
--- a/app/Http/Controllers/Api/ProductCategoryController.php
+++ b/app/Http/Controllers/Api/ProductCategoryController.php
@@ -3,12 +3,13 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProductCategoryRequest;
+use App\Http\Requests\UpdateProductCategoryRequest;
 use App\Http\Resources\ProductCategoryResource;
 use App\Models\ProductCategory;
 use App\Services\ApiService;
 use App\Services\ProductCategoryService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 class ProductCategoryController extends Controller
 {
@@ -67,15 +68,10 @@ class ProductCategoryController extends Controller
      *     @OA\Response(response=500, description="Erreur interne du serveur")
      * )
      */
-    public function store(Request $request): JsonResponse
+    public function store(StoreProductCategoryRequest $request): JsonResponse
     {
         $this->authorize('create', new ProductCategory());
-        $validated = $request->validate([
-            'name' => 'required|array',
-            'name.*' => 'required|string|max:255',
-            'description' => 'nullable|array',
-            'description.*' => 'nullable|string',
-        ]);
+        $validated = $request->validated();
         $category = $this->service->create($validated);
         return ApiService::response(new ProductCategoryResource($category), 201);
     }
@@ -131,15 +127,10 @@ class ProductCategoryController extends Controller
      *     @OA\Response(response=500, description="Erreur serveur interne")
      * )
      */
-    public function update(Request $request, ProductCategory $productCategory): JsonResponse
+    public function update(UpdateProductCategoryRequest $request, ProductCategory $productCategory): JsonResponse
     {
         $this->authorize('update', $productCategory);
-        $validated = $request->validate([
-            'name' => 'required|array',
-            'name.*' => 'required|string|max:255',
-            'description' => 'nullable|array',
-            'description.*' => 'nullable|string',
-        ]);
+        $validated = $request->validated();
         $updated = $this->service->update($productCategory, $validated);
         return ApiService::response(new ProductCategoryResource($updated), 200);
     }

--- a/tests/Feature/Requests/ProductCategoryRequestTest.php
+++ b/tests/Feature/Requests/ProductCategoryRequestTest.php
@@ -40,6 +40,32 @@ class ProductCategoryRequestTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
+    public function test_store_product_category_request_fails_authorization_without_permission(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $request = new StoreProductCategoryRequest();
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_store_product_category_request_fails_validation(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('manage product categories');
+        $this->actingAs($user);
+
+        $request = new StoreProductCategoryRequest();
+
+        $data = [
+            'name' => 'invalid',
+        ];
+
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->fails());
+    }
+
     public function test_update_product_category_request_authorizes_when_user_has_permission(): void
     {
         $user = User::factory()->create();
@@ -57,6 +83,32 @@ class ProductCategoryRequestTest extends TestCase
 
         $validator = Validator::make($data, $request->rules());
         $this->assertTrue($validator->passes());
+    }
+
+    public function test_update_product_category_request_fails_authorization_without_permission(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $request = new UpdateProductCategoryRequest();
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_update_product_category_request_fails_validation(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('manage product categories');
+        $this->actingAs($user);
+
+        $request = new UpdateProductCategoryRequest();
+
+        $data = [
+            'name' => 'invalid',
+        ];
+
+        $validator = Validator::make($data, $request->rules());
+        $this->assertTrue($validator->fails());
     }
 }
 


### PR DESCRIPTION
## Summary
- replace manual request validation with StoreProductCategoryRequest and UpdateProductCategoryRequest
- cover validation and authorization via feature and request tests

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6891fef5173483338d3d92167201175b