### PR TITLE
Allow product category reads without auth

### DIFF
--- a/app/Http/Controllers/Api/ProductCategoryController.php
+++ b/app/Http/Controllers/Api/ProductCategoryController.php
@@ -42,7 +42,6 @@ class ProductCategoryController extends Controller
      */
     public function index(): JsonResponse
     {
-        $this->authorize('view', new ProductCategory());
         $categories = ProductCategory::all();
         return ApiService::response(ProductCategoryResource::collection($categories), 200);
     }
@@ -104,7 +103,6 @@ class ProductCategoryController extends Controller
      */
     public function show(ProductCategory $productCategory): JsonResponse
     {
-        $this->authorize('view', $productCategory);
         return ApiService::response(new ProductCategoryResource($productCategory), 200);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,9 @@ Route::prefix('v1')->group(function () {
     Route::post('/verify-email', [AuthController::class, 'verifyEmail']);
     Route::post('/resend-verification-email', [AuthController::class, 'resendVerificationEmail']);
 
+    // Product Categories - Public
+    Route::apiResource('product-categories', ProductCategoryController::class)->only(['index', 'show']);
+
     /*
     |--------------------------------------------------------------------------
     | Protected Routes - Requires auth
@@ -96,7 +99,7 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('categories', CategoryController::class);
         Route::apiResource('stores', StoreController::class);
         Route::apiResource('products', ProductController::class);
-        Route::apiResource('product-categories', ProductCategoryController::class);
+        Route::apiResource('product-categories', ProductCategoryController::class)->except(['index', 'show']);
 
         Route::prefix('orders')->group(function () {
             Route::get('/', [OrderController::class, 'index']);

--- a/tests/Feature/ProductCategoryTest.php
+++ b/tests/Feature/ProductCategoryTest.php
@@ -99,5 +99,27 @@ class ProductCategoryTest extends TestCase
             'name' => ['en' => 'Updated'],
         ])->assertStatus(403);
     }
+
+    public function test_public_can_view_product_categories_without_token(): void
+    {
+        $category = ProductCategory::create([
+            'name' => ['en' => 'Food'],
+        ]);
+
+        $this->getJson('/api/v1/product-categories')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $category->id]);
+    }
+
+    public function test_public_can_view_single_product_category_without_token(): void
+    {
+        $category = ProductCategory::create([
+            'name' => ['en' => 'Food'],
+        ]);
+
+        $this->getJson("/api/v1/product-categories/{$category->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('id', $category->id);
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose product category list and detail without requiring auth
- keep product category creation and updates behind sanctum auth
- test public product category endpoints

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68920fd241e48333891e941a784111f7