### PR TITLE
Use granular permissions for product categories

### DIFF
--- a/app/Http/Requests/StoreProductCategoryRequest.php
+++ b/app/Http/Requests/StoreProductCategoryRequest.php
@@ -11,7 +11,7 @@ class StoreProductCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return auth()->user()?->can('manage product categories') ?? false;
+        return auth()->user()?->can('create_product_category') ?? false;
     }
 
     /**

--- a/app/Http/Requests/UpdateProductCategoryRequest.php
+++ b/app/Http/Requests/UpdateProductCategoryRequest.php
@@ -11,7 +11,7 @@ class UpdateProductCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return auth()->user()?->can('manage product categories') ?? false;
+        return auth()->user()?->can('edit_any_product_category') ?? false;
     }
 
     /**

--- a/tests/Feature/ProductCategoryTest.php
+++ b/tests/Feature/ProductCategoryTest.php
@@ -18,7 +18,6 @@ class ProductCategoryTest extends TestCase
         'create_product_category',
         'edit_any_product_category',
         'delete_any_product_category',
-        'manage product categories',
     ];
 
     protected function setUp(): void
@@ -80,13 +79,12 @@ class ProductCategoryTest extends TestCase
         $response->assertStatus(422);
     }
 
-    public function test_update_product_category_requires_manage_permission(): void
+    public function test_update_product_category_requires_edit_permission(): void
     {
         $user = User::factory()->create();
         $user->givePermissionTo([
             'view_any_product_category',
             'create_product_category',
-            'edit_any_product_category',
             'delete_any_product_category',
         ]);
         Sanctum::actingAs($user);

--- a/tests/Feature/Requests/ProductCategoryRequestTest.php
+++ b/tests/Feature/Requests/ProductCategoryRequestTest.php
@@ -18,13 +18,14 @@ class ProductCategoryRequestTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Permission::create(['name' => 'manage product categories']);
+        Permission::create(['name' => 'create_product_category']);
+        Permission::create(['name' => 'edit_any_product_category']);
     }
 
     public function test_store_product_category_request_authorizes_when_user_has_permission(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('manage product categories');
+        $user->givePermissionTo('create_product_category');
         $this->actingAs($user);
 
         $request = new StoreProductCategoryRequest();
@@ -53,7 +54,7 @@ class ProductCategoryRequestTest extends TestCase
     public function test_store_product_category_request_fails_validation(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('manage product categories');
+        $user->givePermissionTo('create_product_category');
         $this->actingAs($user);
 
         $request = new StoreProductCategoryRequest();
@@ -69,7 +70,7 @@ class ProductCategoryRequestTest extends TestCase
     public function test_update_product_category_request_authorizes_when_user_has_permission(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('manage product categories');
+        $user->givePermissionTo('edit_any_product_category');
         $this->actingAs($user);
 
         $request = new UpdateProductCategoryRequest();
@@ -98,7 +99,7 @@ class ProductCategoryRequestTest extends TestCase
     public function test_update_product_category_request_fails_validation(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('manage product categories');
+        $user->givePermissionTo('edit_any_product_category');
         $this->actingAs($user);
 
         $request = new UpdateProductCategoryRequest();


### PR DESCRIPTION
## Summary
- replace `manage product categories` gate checks with `create_product_category` and `edit_any_product_category`
- update request and feature tests to match new permissions

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68920fd463488333b7fc677c1bc8dae0