### PR TITLE
Add endpoint to retrieve products for a category

### DIFF
--- a/app/Http/Controllers/Api/ProductCategoryController.php
+++ b/app/Http/Controllers/Api/ProductCategoryController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreProductCategoryRequest;
 use App\Http\Requests\UpdateProductCategoryRequest;
 use App\Http\Resources\ProductCategoryResource;
+use App\Http\Resources\ProductResource;
 use App\Models\ProductCategory;
 use App\Services\ApiService;
 use App\Services\ProductCategoryService;
@@ -104,6 +105,21 @@ class ProductCategoryController extends Controller
     public function show(ProductCategory $productCategory): JsonResponse
     {
         return ApiService::response(new ProductCategoryResource($productCategory), 200);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/product-categories/{id}/products",
+     *     tags={"Product Categories"},
+     *     summary="Obtenir les produits d'une catégorie",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Liste des produits récupérée avec succès")
+     * )
+     */
+    public function products(ProductCategory $productCategory): JsonResponse
+    {
+        $products = $productCategory->products()->with(['category', 'store'])->get();
+        return ApiService::response(ProductResource::collection($products), 200);
     }
 
     /**

--- a/app/Http/Resources/ProductCategoryResource.php
+++ b/app/Http/Resources/ProductCategoryResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\ProductResource;
 
 class ProductCategoryResource extends JsonResource
 {
@@ -20,6 +21,7 @@ class ProductCategoryResource extends JsonResource
             'description' => $this->getTranslations('description'),
             'icon' => $this->icon,
             'color' => $this->color,
+            'products' => ProductResource::collection($this->whenLoaded('products')),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,7 @@ Route::prefix('v1')->group(function () {
 
     // Product Categories - Public
     Route::apiResource('product-categories', ProductCategoryController::class)->only(['index', 'show']);
+    Route::get('product-categories/{productCategory}/products', [ProductCategoryController::class, 'products']);
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/ProductCategoryProductsTest.php
+++ b/tests/Feature/ProductCategoryProductsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\ProductCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductCategoryProductsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_products_for_category(): void
+    {
+        $category = ProductCategory::factory()->create();
+        $products = Product::factory()->count(2)->create([
+            'product_category_id' => $category->id,
+        ]);
+
+        $response = $this->getJson("/api/v1/product-categories/{$category->id}/products");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2)
+            ->assertJsonFragment(['id' => $products[0]->id])
+            ->assertJsonFragment(['id' => $products[1]->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- expose products relationship on `ProductCategoryResource`
- document and implement `ProductCategoryController::products` endpoint
- add public route to fetch a category's products
- cover new endpoint with integration test

## Testing
- `php artisan test tests/Feature/ProductCategoryTest.php tests/Feature/ProductCategoryProductsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68927300e6cc83338036fe369e362cde