### PR TITLE
Validate and assign provider user

### DIFF
--- a/app/Http/Requests/StoreProviderRequest.php
+++ b/app/Http/Requests/StoreProviderRequest.php
@@ -14,6 +14,7 @@ class StoreProviderRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'user_id'         => 'required|exists:users,id|unique:providers,user_id',
             'name'            => 'required|array',
             'name.*'          => 'required|string|max:255',
             'email'           => 'required|email|unique:providers,email',

--- a/app/Services/ProviderService.php
+++ b/app/Services/ProviderService.php
@@ -26,6 +26,7 @@ class ProviderService
         }
 
         $provider = new Provider();
+        $provider->user_id = $data['user_id'];
         $provider->email  = $data['email'];
         $provider->phone  = $data['phone'] ?? null;
         $provider->tax_code = $data['tax_code'] ?? null;


### PR DESCRIPTION
## Summary
- require a valid, unique user ID when creating providers
- associate providers with the provided user ID during creation

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896739c20d08333a5d0e3a2ef8933c1