### PR TITLE
Allow updating provider user relation

### DIFF
--- a/app/Http/Requests/UpdateProviderRequest.php
+++ b/app/Http/Requests/UpdateProviderRequest.php
@@ -14,6 +14,7 @@ class UpdateProviderRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'user_id'        => 'sometimes|exists:users,id|unique:providers,user_id,' . $this->provider,
             'name'            => 'sometimes|array',
             'name.*'          => 'sometimes|string|max:255',
             'email'           => 'sometimes|email|unique:providers,email,' . $this->provider,

--- a/app/Services/ProviderService.php
+++ b/app/Services/ProviderService.php
@@ -53,6 +53,9 @@ class ProviderService
         if (isset($data['email'])) {
             $provider->email = $data['email'];
         }
+        if (isset($data['user_id'])) {
+            $provider->user_id = $data['user_id'];
+        }
         if (isset($data['phone'])) {
             $provider->phone = $data['phone'];
         }


### PR DESCRIPTION
## Summary
- add validation for optional provider user reference in update request
- support updating provider's user relationship in service layer

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896739c3c248333a37fdf35f583cd83