### PR TITLE
Force JSON responses for API routes

### DIFF
--- a/app/Http/Middleware/ForceJsonResponse.php
+++ b/app/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class ForceJsonResponse
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle($request, Closure $next)
+    {
+        $accept = $request->header('Accept');
+
+        if ($accept && $accept !== '*/*' && ! str_contains($accept, 'application/json')) {
+            return response()->json([
+                'message' => 'Not Acceptable.',
+            ], SymfonyResponse::HTTP_NOT_ACCEPTABLE);
+        }
+
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\HandleCors;
+use App\Http\Middleware\ForceJsonResponse;
 
 return Application::configure(
     basePath: dirname(__DIR__)
@@ -27,6 +28,8 @@ return Application::configure(
             'locale' => \App\Http\Middleware\SetLocale::class,
             'permission' => \App\Http\Middleware\CheckPermission::class,
         ]);
+
+        $middleware->appendToGroup('api', ForceJsonResponse::class);
 
         // Exemple si tu veux ajouter d’autres alias :
         // $middleware->alias([


### PR DESCRIPTION
## Summary
- add middleware that forces `Accept: application/json` or returns 406 when a non-JSON response is requested
- register middleware within the API middleware stack so all `/api` routes enforce JSON responses

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6896811c23748333a5694e4dbbc25ab3