### PR TITLE
Add StoreCategory model and migration

### DIFF
--- a/app/Models/StoreCategory.php
+++ b/app/Models/StoreCategory.php
@@ -1,0 +1,38 @@
+<?php
+
+// app/Models/StoreCategory.php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Translatable\HasTranslations;
+
+class StoreCategory extends Model
+{
+    use HasFactory, HasTranslations;
+
+    protected $fillable = [
+        'store_id',
+        'name',
+        'slug',
+        'parent_id',
+    ];
+
+    public $translatable = ['name'];
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children()
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+}

--- a/database/migrations/2025_10_09_000000_create_store_categories_table.php
+++ b/database/migrations/2025_10_09_000000_create_store_categories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('store_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+            $table->json('name');
+            $table->string('slug')->unique();
+            $table->foreignId('parent_id')->nullable()->constrained('store_categories')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('store_categories');
+    }
+};


### PR DESCRIPTION
## Summary
- add `StoreCategory` model with translations and relationships
- create migration for `store_categories` table with foreign keys

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b093c0e45483339c9e9ab7bb0025e6