### PR TITLE
Add request validation for store categories

### DIFF
--- a/app/Http/Requests/StoreStoreCategoryRequest.php
+++ b/app/Http/Requests/StoreStoreCategoryRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Store;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreStoreCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $storeId = Store::where('user_id', $this->user()->id)->value('id') ?? 0;
+
+        return [
+            'name' => ['required', 'array'],
+            'name.*' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('store_categories', 'slug')->where(fn($query) => $query->where('store_id', $storeId)),
+            ],
+            'parent_id' => ['nullable', 'exists:store_categories,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateStoreCategoryRequest.php
+++ b/app/Http/Requests/UpdateStoreCategoryRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Store;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateStoreCategoryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $categoryId = $this->route('id');
+        $storeId = Store::where('user_id', $this->user()->id)->value('id') ?? 0;
+
+        return [
+            'name' => ['sometimes', 'array'],
+            'name.*' => ['required_with:name', 'string', 'max:255'],
+            'slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('store_categories', 'slug')
+                    ->ignore($categoryId)
+                    ->where(fn($query) => $query->where('store_id', $storeId)),
+            ],
+            'parent_id' => ['nullable', 'exists:store_categories,id'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add `StoreStoreCategoryRequest` for creating store categories
- add `UpdateStoreCategoryRequest` for updating store categories with unique slug per store and optional parent

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ac9ddb2083338b19ab97f13f4e78