### PR TITLE
Add admin dashboard statistics endpoint

### DIFF
--- a/app/Http/Controllers/Api/AdminDashboardController.php
+++ b/app/Http/Controllers/Api/AdminDashboardController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AdminDashboard;
+use App\Services\AdminDashboardService;
+use App\Services\ApiService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Admin Dashboard", description="Statistiques globales pour l'administration")
+ */
+class AdminDashboardController extends Controller
+{
+    public function __construct(private readonly AdminDashboardService $dashboardService)
+    {
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/admin/dashboard/stats",
+     *     tags={"Admin Dashboard"},
+     *     summary="Récupérer les statistiques du tableau de bord administrateur",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="date_from",
+     *         in="query",
+     *         required=false,
+     *         description="Filtrer à partir de cette date (format YYYY-MM-DD)",
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Parameter(
+     *         name="date_to",
+     *         in="query",
+     *         required=false,
+     *         description="Filtrer jusqu'à cette date (format YYYY-MM-DD)",
+     *         @OA\Schema(type="string", format="date")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Statistiques calculées",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="total_revenue", type="number", format="float", example=1250.50),
+     *             @OA\Property(property="orders_volume", type="integer", example=45),
+     *             @OA\Property(property="average_order_value", type="number", format="float", example=27.78),
+     *             @OA\Property(property="pending_orders", type="integer", example=5),
+     *             @OA\Property(property="completed_orders", type="integer", example=30),
+     *             @OA\Property(property="bookings_volume", type="integer", example=12),
+     *             @OA\Property(property="pending_bookings", type="integer", example=3),
+     *             @OA\Property(property="pending_users", type="integer", example=4),
+     *             @OA\Property(property="pending_providers", type="integer", example=2),
+     *             @OA\Property(property="total_users", type="integer", example=150),
+     *             @OA\Property(property="total_providers", type="integer", example=40)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Non authentifié"),
+     *     @OA\Response(response=403, description="Accès interdit"),
+     *     @OA\Response(response=500, description="Erreur interne du serveur")
+     * )
+     */
+    public function stats(Request $request): JsonResponse
+    {
+        try {
+            $this->authorize('view', AdminDashboard::class);
+
+            $filters = $request->only(['date_from', 'date_to']);
+            $stats = $this->dashboardService->getStats($filters);
+
+            return ApiService::response($stats, 200);
+        } catch (AuthorizationException $exception) {
+            return ApiService::response($exception->getMessage(), 403);
+        } catch (\Throwable $exception) {
+            return ApiService::response($exception->getMessage(), 500);
+        }
+    }
+}

--- a/app/Models/AdminDashboard.php
+++ b/app/Models/AdminDashboard.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Models;
+
+class AdminDashboard
+{
+    // This class acts as a policy target for the admin dashboard endpoints.
+}

--- a/app/Policies/AdminDashboardPolicy.php
+++ b/app/Policies/AdminDashboardPolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class AdminDashboardPolicy
+{
+    public function view(User $user): bool
+    {
+        if ($user->hasAnyRole(['admin', 'super-admin'])) {
+            return true;
+        }
+
+        return $user->can('view_admin_dashboard');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ use App\Models\Store;
 use App\Models\Order;
 use App\Models\CartItem;
 use App\Models\Product;
+use App\Models\AdminDashboard;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Gate;
@@ -36,6 +37,7 @@ use App\Policies\OrderPolicy;
 use App\Policies\UserPolicy;
 use App\Policies\CartItemPolicy;
 use App\Policies\ProductPolicy;
+use App\Policies\AdminDashboardPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -61,6 +63,7 @@ class AuthServiceProvider extends ServiceProvider
         Order::class           => OrderPolicy::class,
         CartItem::class        => CartItemPolicy::class,
         User::class            => UserPolicy::class,
+        AdminDashboard::class  => AdminDashboardPolicy::class,
     ];
 
     public function boot(): void

--- a/app/Services/AdminDashboardService.php
+++ b/app/Services/AdminDashboardService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Booking;
+use App\Models\Order;
+use App\Models\Provider;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+
+class AdminDashboardService
+{
+    public function getStats(array $filters = []): array
+    {
+        $from = $this->parseDate($filters['date_from'] ?? null, true);
+        $to = $this->parseDate($filters['date_to'] ?? null, false);
+
+        $orderQuery = Order::query();
+        $this->applyDateRange($orderQuery, $from, $to);
+
+        $totalRevenue = (float) (clone $orderQuery)->sum('total');
+        $ordersVolume = (clone $orderQuery)->count();
+        $pendingOrders = (clone $orderQuery)->where('status', 'pending')->count();
+        $completedOrders = (clone $orderQuery)->where('status', 'completed')->count();
+
+        $averageOrderValue = $ordersVolume > 0
+            ? round($totalRevenue / $ordersVolume, 2)
+            : 0.0;
+
+        $bookingQuery = Booking::query();
+        $this->applyDateRange($bookingQuery, $from, $to);
+
+        $bookingsVolume = (clone $bookingQuery)->count();
+        $pendingBookings = (clone $bookingQuery)->where('status', 'pending')->count();
+
+        $pendingUsers = User::where('status', 'pending')->count();
+        $pendingProviders = Provider::whereHas('user', function ($query) {
+            $query->where('status', 'pending');
+        })->count();
+
+        return [
+            'total_revenue' => $totalRevenue,
+            'orders_volume' => $ordersVolume,
+            'average_order_value' => $averageOrderValue,
+            'pending_orders' => $pendingOrders,
+            'completed_orders' => $completedOrders,
+            'bookings_volume' => $bookingsVolume,
+            'pending_bookings' => $pendingBookings,
+            'pending_users' => $pendingUsers,
+            'pending_providers' => $pendingProviders,
+            'total_users' => User::count(),
+            'total_providers' => Provider::count(),
+        ];
+    }
+
+    private function applyDateRange(Builder $query, ?Carbon $from, ?Carbon $to): void
+    {
+        if ($from) {
+            $query->where('created_at', '>=', $from);
+        }
+
+        if ($to) {
+            $query->where('created_at', '<=', $to);
+        }
+    }
+
+    private function parseDate(?string $value, bool $startOfDay): ?Carbon
+    {
+        if (!$value) {
+            return null;
+        }
+
+        $date = Carbon::parse($value);
+
+        return $startOfDay ? $date->startOfDay() : $date->endOfDay();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,10 +23,12 @@ use App\Http\Controllers\Api\{
     CheckoutController,
     ShippingStatusController,
     PaymentController,
-    StripeWebhookController
+    StripeWebhookController,
+    AdminDashboardController
 };
 use App\Http\Controllers\Api\ProductCategoryController;
 use App\Http\Controllers\Api\StoreCategoryController;
+use App\Models\AdminDashboard;
 
 
 Route::prefix('v1')->group(function () {
@@ -240,6 +242,12 @@ Route::prefix('v1')->group(function () {
 
 
         Route::post('/stripe/webhook', [StripeWebhookController::class, 'handleWebhook']);
+
+        Route::prefix('admin/dashboard')
+            ->middleware(['can:view,' . AdminDashboard::class])
+            ->group(function () {
+                Route::get('/stats', [AdminDashboardController::class, 'stats']);
+            });
 
 
     });

--- a/tests/Feature/Admin/DashboardStatsTest.php
+++ b/tests/Feature/Admin/DashboardStatsTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Booking;
+use App\Models\Category;
+use App\Models\Order;
+use App\Models\Provider;
+use App\Models\Service;
+use App\Models\Store;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class DashboardStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authentication_is_required(): void
+    {
+        $this->getJson('/api/v1/admin/dashboard/stats')->assertStatus(401);
+    }
+
+    public function test_permission_is_required(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/admin/dashboard/stats')
+            ->assertStatus(403);
+    }
+
+    public function test_it_returns_aggregated_stats_with_date_filters(): void
+    {
+        $admin = User::factory()->create();
+        Permission::create(['name' => 'view_admin_dashboard']);
+        $admin->givePermissionTo('view_admin_dashboard');
+        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $store = Store::factory()->create();
+        $customer = User::factory()->create();
+
+        $orderInRangeCompleted = Order::create([
+            'user_id' => $customer->id,
+            'store_id' => $store->id,
+            'total' => 120,
+            'status' => 'completed',
+        ]);
+        Order::whereKey($orderInRangeCompleted->id)->update([
+            'created_at' => Carbon::parse('2024-02-10 10:00:00'),
+            'updated_at' => Carbon::parse('2024-02-10 10:00:00'),
+        ]);
+
+        $orderInRangePending = Order::create([
+            'user_id' => $customer->id,
+            'store_id' => $store->id,
+            'total' => 80,
+            'status' => 'pending',
+        ]);
+        Order::whereKey($orderInRangePending->id)->update([
+            'created_at' => Carbon::parse('2024-02-15 12:00:00'),
+            'updated_at' => Carbon::parse('2024-02-15 12:00:00'),
+        ]);
+
+        $orderOutOfRange = Order::create([
+            'user_id' => $customer->id,
+            'store_id' => $store->id,
+            'total' => 200,
+            'status' => 'completed',
+        ]);
+        Order::whereKey($orderOutOfRange->id)->update([
+            'created_at' => Carbon::parse('2023-12-25 08:00:00'),
+            'updated_at' => Carbon::parse('2023-12-25 08:00:00'),
+        ]);
+
+        $pendingProviderUser = User::factory()->create(['status' => 'pending']);
+        $activeProviderUser = User::factory()->create();
+        User::factory()->create(['status' => 'pending']);
+
+        $pendingProvider = Provider::create([
+            'user_id' => $pendingProviderUser->id,
+            'name' => ['en' => 'Pending Provider'],
+            'email' => 'pending-provider@example.com',
+        ]);
+
+        $activeProvider = Provider::create([
+            'user_id' => $activeProviderUser->id,
+            'name' => ['en' => 'Active Provider'],
+            'email' => 'active-provider@example.com',
+        ]);
+
+        $category = Category::create([
+            'name' => ['en' => 'Care'],
+            'icon' => 'fa-paw',
+            'type' => 'service',
+            'color' => '#FF0000',
+        ]);
+
+        $service = Service::create([
+            'name' => ['en' => 'Grooming'],
+            'description' => ['en' => 'Full grooming'],
+            'category_id' => $category->id,
+            'price' => 45,
+            'active' => true,
+        ]);
+
+        $bookingInRangePending = Booking::create([
+            'service_id' => $service->id,
+            'provider_id' => $activeProvider->id,
+            'user_id' => $customer->id,
+            'animal_id' => null,
+            'appointment_date' => Carbon::parse('2024-03-01 09:00:00'),
+            'time' => '09:00',
+            'payment_intent' => 'pi_123',
+            'currency' => 'eur',
+            'status' => 'pending',
+        ]);
+        Booking::whereKey($bookingInRangePending->id)->update([
+            'created_at' => Carbon::parse('2024-02-20 09:00:00'),
+            'updated_at' => Carbon::parse('2024-02-20 09:00:00'),
+        ]);
+
+        $bookingInRangeConfirmed = Booking::create([
+            'service_id' => $service->id,
+            'provider_id' => $activeProvider->id,
+            'user_id' => $customer->id,
+            'animal_id' => null,
+            'appointment_date' => Carbon::parse('2024-03-05 11:00:00'),
+            'time' => '11:00',
+            'payment_intent' => 'pi_456',
+            'currency' => 'eur',
+            'status' => 'confirmed',
+        ]);
+        Booking::whereKey($bookingInRangeConfirmed->id)->update([
+            'created_at' => Carbon::parse('2024-02-22 11:00:00'),
+            'updated_at' => Carbon::parse('2024-02-22 11:00:00'),
+        ]);
+
+        $bookingOutOfRange = Booking::create([
+            'service_id' => $service->id,
+            'provider_id' => $activeProvider->id,
+            'user_id' => $customer->id,
+            'animal_id' => null,
+            'appointment_date' => Carbon::parse('2023-11-10 14:00:00'),
+            'time' => '14:00',
+            'payment_intent' => 'pi_789',
+            'currency' => 'eur',
+            'status' => 'pending',
+        ]);
+        Booking::whereKey($bookingOutOfRange->id)->update([
+            'created_at' => Carbon::parse('2023-11-10 14:00:00'),
+            'updated_at' => Carbon::parse('2023-11-10 14:00:00'),
+        ]);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->getJson('/api/v1/admin/dashboard/stats?date_from=2024-02-01&date_to=2024-03-01');
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'total_revenue' => 200.0,
+            'orders_volume' => 2,
+            'average_order_value' => 100.0,
+            'pending_orders' => 1,
+            'completed_orders' => 1,
+            'bookings_volume' => 2,
+            'pending_bookings' => 1,
+            'pending_users' => 2,
+            'pending_providers' => 1,
+            'total_users' => 6,
+            'total_providers' => 2,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin dashboard controller, service and policy to expose aggregated stats with OpenAPI docs
- secure the new `/admin/dashboard/stats` route via Sanctum and the dedicated policy
- cover the new endpoint with feature tests that verify authorization and aggregation logic

## Testing
- php artisan test --filter=DashboardStatsTest

------
https://chatgpt.com/codex/tasks/task_e_68d7f5d0b47c8333a4deee840643cecf