### PR TITLE
Add coupon, inventory, and store setting marketplace APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,31 @@ creating a new token on the user and deleting the old one.
 
 After updating the Sanctum configuration, run `php artisan config:clear`
 when deploying to ensure the new settings are applied.
+
+## Marketplace APIs
+
+The marketplace module exposes dedicated endpoints for coupons, inventory tracking and store configuration. All routes are available under the `/api/v1` prefix and protected by the `auth:sanctum` and `locale` middlewares unless stated otherwise.
+
+### Coupons
+
+- `GET /api/v1/coupons` — List coupons with optional filters (`store_id`, `code`, `is_active`).
+- `POST /api/v1/coupons` — Create a coupon linked to a store and optionally to a product.
+- `GET /api/v1/coupons/{id}` — Retrieve coupon details.
+- `PUT /api/v1/coupons/{id}` — Update coupon metadata or activation settings.
+- `DELETE /api/v1/coupons/{id}` — Remove a coupon.
+
+### Inventory Movements
+
+- `GET /api/v1/inventory-movements` — Paginated history of stock adjustments per store/product.
+- `POST /api/v1/inventory-movements` — Register an incoming or outgoing stock movement and update product stock.
+- `GET /api/v1/inventory-movements/{id}` — Inspect a specific movement.
+- `PUT /api/v1/inventory-movements/{id}` — Amend the movement (type, quantity, notes) while keeping stock consistent.
+- `DELETE /api/v1/inventory-movements/{id}` — Roll back the movement and restore product stock.
+
+### Store Settings
+
+- `GET /api/v1/store-settings` — List settings for all stores.
+- `POST /api/v1/store-settings` — Create configuration for a store (currency, timezone, notifications, etc.).
+- `GET /api/v1/store-settings/{id}` — Display a store setting with its related store.
+- `PUT /api/v1/store-settings/{id}` — Update configuration values such as locale or low stock threshold.
+- `DELETE /api/v1/store-settings/{id}` — Remove the configuration record.

--- a/app/Http/Controllers/Api/CouponController.php
+++ b/app/Http/Controllers/Api/CouponController.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCouponRequest;
+use App\Http\Requests\UpdateCouponRequest;
+use App\Http\Resources\CouponResource;
+use App\Models\Coupon;
+use App\Services\ApiService;
+use App\Services\CouponService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Coupons", description="Gestion des coupons")
+ */
+class CouponController extends Controller
+{
+    public function __construct(private readonly CouponService $couponService)
+    {
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/coupons",
+     *     tags={"Coupons"},
+     *     summary="Liste des coupons",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="store_id", in="query", @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="code", in="query", @OA\Schema(type="string")),
+     *     @OA\Parameter(name="is_active", in="query", @OA\Schema(type="boolean")),
+     *     @OA\Response(response=200, description="Liste des coupons"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $this->authorize('view', new Coupon());
+
+            $coupons = $this->couponService->list($request->only(['store_id', 'code', 'is_active', 'per_page']));
+
+            $resource = CouponResource::collection($coupons)->additional([
+                'meta' => ['total' => $coupons->total()],
+            ]);
+
+            return ApiService::response($resource, 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/coupons",
+     *     tags={"Coupons"},
+     *     summary="Créer un coupon",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(
+     *         required={"store_id","code","name","discount_type","discount_value"},
+     *         @OA\Property(property="store_id", type="integer"),
+     *         @OA\Property(property="product_id", type="integer"),
+     *         @OA\Property(property="code", type="string"),
+     *         @OA\Property(property="name", type="object"),
+     *         @OA\Property(property="description", type="object"),
+     *         @OA\Property(property="discount_type", type="string", enum={"percentage","fixed"}),
+     *         @OA\Property(property="discount_value", type="number", format="float"),
+     *         @OA\Property(property="minimum_order_total", type="number", format="float"),
+     *         @OA\Property(property="usage_limit", type="integer"),
+     *         @OA\Property(property="starts_at", type="string", format="date-time"),
+     *         @OA\Property(property="expires_at", type="string", format="date-time"),
+     *         @OA\Property(property="is_active", type="boolean")
+     *     )),
+     *     @OA\Response(response=201, description="Coupon créé"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
+    public function store(StoreCouponRequest $request): JsonResponse
+    {
+        try {
+            $this->authorize('create', new Coupon());
+
+            $data = $request->validated();
+            $data['created_by'] = $data['created_by'] ?? $request->user()->id;
+
+            $coupon = $this->couponService->create($data);
+
+            return ApiService::response(new CouponResource($coupon->load(['store', 'product', 'creator'])), 201);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/coupons/{coupon}",
+     *     tags={"Coupons"},
+     *     summary="Afficher un coupon",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="coupon", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Coupon récupéré"),
+     *     @OA\Response(response=404, description="Coupon introuvable")
+     * )
+     */
+    public function show(Coupon $coupon): JsonResponse
+    {
+        try {
+            $this->authorize('view', $coupon);
+            $coupon->load(['store', 'product', 'creator']);
+
+            return ApiService::response(new CouponResource($coupon), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Coupon not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/coupons/{coupon}",
+     *     tags={"Coupons"},
+     *     summary="Mettre à jour un coupon",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="coupon", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Coupon mis à jour"),
+     *     @OA\Response(response=404, description="Coupon introuvable"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
+    public function update(UpdateCouponRequest $request, Coupon $coupon): JsonResponse
+    {
+        try {
+            $this->authorize('update', $coupon);
+
+            $updated = $this->couponService->update($coupon, $request->validated());
+
+            return ApiService::response(new CouponResource($updated), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Coupon not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/coupons/{coupon}",
+     *     tags={"Coupons"},
+     *     summary="Supprimer un coupon",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="coupon", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=204, description="Coupon supprimé"),
+     *     @OA\Response(response=404, description="Coupon introuvable")
+     * )
+     */
+    public function destroy(Coupon $coupon): JsonResponse
+    {
+        try {
+            $this->authorize('delete', $coupon);
+
+            $this->couponService->delete($coupon);
+
+            return ApiService::response(['message' => 'Coupon deleted'], 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Coupon not found', 404);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/InventoryController.php
+++ b/app/Http/Controllers/Api/InventoryController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreInventoryMovementRequest;
+use App\Http\Requests\UpdateInventoryMovementRequest;
+use App\Http\Resources\InventoryMovementResource;
+use App\Models\InventoryMovement;
+use App\Services\ApiService;
+use App\Services\InventoryMovementService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Inventory", description="Gestion des mouvements de stock")
+ */
+class InventoryController extends Controller
+{
+    public function __construct(private readonly InventoryMovementService $inventoryMovementService)
+    {
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/inventory-movements",
+     *     tags={"Inventory"},
+     *     summary="Liste des mouvements de stock",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="store_id", in="query", @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="product_id", in="query", @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="movement_type", in="query", @OA\Schema(type="string", enum={"in","out"})),
+     *     @OA\Response(response=200, description="Liste récupérée"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $this->authorize('view', new InventoryMovement());
+
+            $movements = $this->inventoryMovementService->list($request->only(['store_id', 'product_id', 'movement_type', 'per_page']));
+            $resource = InventoryMovementResource::collection($movements)->additional([
+                'meta' => ['total' => $movements->total()],
+            ]);
+
+            return ApiService::response($resource, 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/inventory-movements",
+     *     tags={"Inventory"},
+     *     summary="Créer un mouvement de stock",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=201, description="Mouvement créé"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
+    public function store(StoreInventoryMovementRequest $request): JsonResponse
+    {
+        try {
+            $this->authorize('create', new InventoryMovement());
+
+            $data = $request->validated();
+            $data['user_id'] = $data['user_id'] ?? $request->user()->id;
+
+            $movement = $this->inventoryMovementService->create($data);
+
+            return ApiService::response(new InventoryMovementResource($movement), 201);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/inventory-movements/{movement}",
+     *     tags={"Inventory"},
+     *     summary="Afficher un mouvement",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="movement", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Mouvement récupéré"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function show(InventoryMovement $movement): JsonResponse
+    {
+        try {
+            $this->authorize('view', $movement);
+
+            return ApiService::response(new InventoryMovementResource($movement->load(['store', 'product', 'user'])), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Inventory movement not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/inventory-movements/{movement}",
+     *     tags={"Inventory"},
+     *     summary="Mettre à jour un mouvement",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="movement", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Mouvement mis à jour"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function update(UpdateInventoryMovementRequest $request, InventoryMovement $movement): JsonResponse
+    {
+        try {
+            $this->authorize('update', $movement);
+
+            $updated = $this->inventoryMovementService->update($movement, $request->validated());
+
+            return ApiService::response(new InventoryMovementResource($updated), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Inventory movement not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/inventory-movements/{movement}",
+     *     tags={"Inventory"},
+     *     summary="Supprimer un mouvement",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="movement", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Mouvement supprimé"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function destroy(InventoryMovement $movement): JsonResponse
+    {
+        try {
+            $this->authorize('delete', $movement);
+
+            $this->inventoryMovementService->delete($movement);
+
+            return ApiService::response(['message' => 'Inventory movement deleted'], 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Inventory movement not found', 404);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/StoreSettingController.php
+++ b/app/Http/Controllers/Api/StoreSettingController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreStoreSettingRequest;
+use App\Http\Requests\UpdateStoreSettingRequest;
+use App\Http\Resources\StoreSettingResource;
+use App\Models\StoreSetting;
+use App\Services\ApiService;
+use App\Services\StoreSettingService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Tag(name="Store Settings", description="Configuration des magasins")
+ */
+class StoreSettingController extends Controller
+{
+    public function __construct(private readonly StoreSettingService $storeSettingService)
+    {
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/store-settings",
+     *     tags={"Store Settings"},
+     *     summary="Liste des configurations",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=200, description="Liste des paramètres"),
+     *     @OA\Response(response=500, description="Erreur serveur")
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        try {
+            $this->authorize('view', new StoreSetting());
+
+            $settings = $this->storeSettingService->list();
+
+            return ApiService::response(StoreSettingResource::collection($settings), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/store-settings",
+     *     tags={"Store Settings"},
+     *     summary="Créer une configuration",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Response(response=201, description="Paramètres créés"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
+    public function store(StoreStoreSettingRequest $request): JsonResponse
+    {
+        try {
+            $this->authorize('create', new StoreSetting());
+
+            $setting = $this->storeSettingService->create($request->validated());
+
+            return ApiService::response(new StoreSettingResource($setting), 201);
+        } catch (\Throwable $e) {
+            return ApiService::response($e->getMessage(), 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/store-settings/{setting}",
+     *     tags={"Store Settings"},
+     *     summary="Afficher une configuration",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="setting", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Paramètres"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function show(StoreSetting $setting): JsonResponse
+    {
+        try {
+            $this->authorize('view', $setting);
+
+            return ApiService::response(new StoreSettingResource($setting->load('store')), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store setting not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *     path="/store-settings/{setting}",
+     *     tags={"Store Settings"},
+     *     summary="Mettre à jour une configuration",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="setting", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Paramètres mis à jour"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function update(UpdateStoreSettingRequest $request, StoreSetting $setting): JsonResponse
+    {
+        try {
+            $this->authorize('update', $setting);
+
+            $updated = $this->storeSettingService->update($setting, $request->validated());
+
+            return ApiService::response(new StoreSettingResource($updated), 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store setting not found', 404);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/store-settings/{setting}",
+     *     tags={"Store Settings"},
+     *     summary="Supprimer une configuration",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="setting", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Paramètres supprimés"),
+     *     @OA\Response(response=404, description="Introuvable")
+     * )
+     */
+    public function destroy(StoreSetting $setting): JsonResponse
+    {
+        try {
+            $this->authorize('delete', $setting);
+
+            $this->storeSettingService->delete($setting);
+
+            return ApiService::response(['message' => 'Store setting deleted'], 200);
+        } catch (\Throwable $e) {
+            return ApiService::response('Store setting not found', 404);
+        }
+    }
+}

--- a/app/Http/Requests/StoreCouponRequest.php
+++ b/app/Http/Requests/StoreCouponRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCouponRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'store_id'            => 'required|exists:stores,id',
+            'product_id'          => 'nullable|exists:products,id',
+            'created_by'          => 'nullable|exists:users,id',
+            'code'                => 'required|string|max:50|unique:coupons,code',
+            'name'                => 'required|array',
+            'name.*'              => 'required|string|max:255',
+            'description'         => 'nullable|array',
+            'description.*'       => 'nullable|string',
+            'discount_type'       => 'required|in:percentage,fixed',
+            'discount_value'      => 'required|numeric|min:0',
+            'minimum_order_total' => 'nullable|numeric|min:0',
+            'usage_limit'         => 'nullable|integer|min:1',
+            'starts_at'           => 'nullable|date',
+            'expires_at'          => 'nullable|date|after_or_equal:starts_at',
+            'is_active'           => 'sometimes|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreInventoryMovementRequest.php
+++ b/app/Http/Requests/StoreInventoryMovementRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInventoryMovementRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'store_id'      => 'required|exists:stores,id',
+            'product_id'    => 'required|exists:products,id',
+            'user_id'       => 'nullable|exists:users,id',
+            'movement_type' => 'required|in:in,out',
+            'quantity'      => 'required|integer|min:1',
+            'reference'     => 'nullable|string|max:255',
+            'notes'         => 'nullable|string',
+            'occurred_at'   => 'nullable|date',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreStoreSettingRequest.php
+++ b/app/Http/Requests/StoreStoreSettingRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStoreSettingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'store_id'              => 'required|exists:stores,id',
+            'currency'              => 'required|string|max:10',
+            'timezone'              => 'required|string|max:255',
+            'locale'                => 'required|string|max:10',
+            'inventory_tracking'    => 'required|boolean',
+            'notifications_enabled' => 'required|boolean',
+            'low_stock_threshold'   => 'required|integer|min:0',
+            'metadata'              => 'nullable|array',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCouponRequest.php
+++ b/app/Http/Requests/UpdateCouponRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCouponRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'store_id'            => 'sometimes|exists:stores,id',
+            'product_id'          => 'nullable|exists:products,id',
+            'created_by'          => 'nullable|exists:users,id',
+            'code'                => [
+                'sometimes',
+                'string',
+                'max:50',
+                Rule::unique('coupons', 'code')->ignore($this->route('coupon')),
+            ],
+            'name'                => 'sometimes|array',
+            'name.*'              => 'required_with:name|string|max:255',
+            'description'         => 'nullable|array',
+            'description.*'       => 'nullable|string',
+            'discount_type'       => 'sometimes|in:percentage,fixed',
+            'discount_value'      => 'sometimes|numeric|min:0',
+            'minimum_order_total' => 'nullable|numeric|min:0',
+            'usage_limit'         => 'nullable|integer|min:1',
+            'used_count'          => 'nullable|integer|min:0',
+            'starts_at'           => 'nullable|date',
+            'expires_at'          => 'nullable|date|after_or_equal:starts_at',
+            'is_active'           => 'sometimes|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateInventoryMovementRequest.php
+++ b/app/Http/Requests/UpdateInventoryMovementRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateInventoryMovementRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'movement_type' => 'sometimes|in:in,out',
+            'quantity'      => 'sometimes|integer|min:1',
+            'reference'     => 'nullable|string|max:255',
+            'notes'         => 'nullable|string',
+            'occurred_at'   => 'nullable|date',
+            'store_id'      => 'prohibited',
+            'product_id'    => 'prohibited',
+            'user_id'       => 'nullable|exists:users,id',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateStoreSettingRequest.php
+++ b/app/Http/Requests/UpdateStoreSettingRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStoreSettingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'currency'              => 'sometimes|string|max:10',
+            'timezone'              => 'sometimes|string|max:255',
+            'locale'                => 'sometimes|string|max:10',
+            'inventory_tracking'    => 'sometimes|boolean',
+            'notifications_enabled' => 'sometimes|boolean',
+            'low_stock_threshold'   => 'sometimes|integer|min:0',
+            'metadata'              => 'nullable|array',
+        ];
+    }
+}

--- a/app/Http/Resources/CouponResource.php
+++ b/app/Http/Resources/CouponResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CouponResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'                  => $this->id,
+            'store_id'            => $this->store_id,
+            'product_id'          => $this->product_id,
+            'code'                => $this->code,
+            'name'                => $this->getTranslations('name'),
+            'description'         => $this->getTranslations('description'),
+            'discount_type'       => $this->discount_type,
+            'discount_value'      => (float) $this->discount_value,
+            'minimum_order_total' => $this->minimum_order_total ? (float) $this->minimum_order_total : null,
+            'usage_limit'         => $this->usage_limit,
+            'used_count'          => $this->used_count,
+            'starts_at'           => optional($this->starts_at)->toIso8601String(),
+            'expires_at'          => optional($this->expires_at)->toIso8601String(),
+            'is_active'           => (bool) $this->is_active,
+            'store'               => new StoreResource($this->whenLoaded('store')),
+            'product'             => new ProductResource($this->whenLoaded('product')),
+            'creator'             => new UserResource($this->whenLoaded('creator')),
+            'created_at'          => optional($this->created_at)->toIso8601String(),
+            'updated_at'          => optional($this->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/InventoryMovementResource.php
+++ b/app/Http/Resources/InventoryMovementResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InventoryMovementResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'            => $this->id,
+            'store_id'      => $this->store_id,
+            'product_id'    => $this->product_id,
+            'user_id'       => $this->user_id,
+            'movement_type' => $this->movement_type,
+            'quantity'      => $this->quantity,
+            'reference'     => $this->reference,
+            'notes'         => $this->notes,
+            'occurred_at'   => optional($this->occurred_at)->toIso8601String(),
+            'store'         => new StoreResource($this->whenLoaded('store')),
+            'product'       => new ProductResource($this->whenLoaded('product')),
+            'user'          => new UserResource($this->whenLoaded('user')),
+            'created_at'    => optional($this->created_at)->toIso8601String(),
+            'updated_at'    => optional($this->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/StoreSettingResource.php
+++ b/app/Http/Resources/StoreSettingResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreSettingResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'                     => $this->id,
+            'store_id'               => $this->store_id,
+            'currency'               => $this->currency,
+            'timezone'               => $this->timezone,
+            'locale'                 => $this->locale,
+            'inventory_tracking'     => (bool) $this->inventory_tracking,
+            'notifications_enabled'  => (bool) $this->notifications_enabled,
+            'low_stock_threshold'    => $this->low_stock_threshold,
+            'metadata'               => $this->metadata,
+            'created_at'             => optional($this->created_at)->toIso8601String(),
+            'updated_at'             => optional($this->updated_at)->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Translatable\HasTranslations;
+
+class Coupon extends Model
+{
+    use HasFactory;
+    use HasTranslations;
+
+    protected $fillable = [
+        'store_id',
+        'product_id',
+        'created_by',
+        'code',
+        'name',
+        'description',
+        'discount_type',
+        'discount_value',
+        'minimum_order_total',
+        'usage_limit',
+        'used_count',
+        'starts_at',
+        'expires_at',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active'            => 'boolean',
+        'starts_at'            => 'datetime',
+        'expires_at'           => 'datetime',
+        'discount_value'       => 'decimal:2',
+        'minimum_order_total'  => 'decimal:2',
+    ];
+
+    public array $translatable = ['name', 'description'];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/InventoryMovement.php
+++ b/app/Models/InventoryMovement.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InventoryMovement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'store_id',
+        'product_id',
+        'user_id',
+        'movement_type',
+        'quantity',
+        'reference',
+        'notes',
+        'occurred_at',
+    ];
+
+    protected $casts = [
+        'occurred_at' => 'datetime',
+    ];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -33,5 +33,15 @@ class Product extends Model
     {
         return $this->belongsTo(Store::class);
     }
+
+    public function coupons()
+    {
+        return $this->hasMany(Coupon::class);
+    }
+
+    public function inventoryMovements()
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
 }
 

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -32,6 +32,21 @@ class Store extends Model
         return $this->hasMany(Product::class);
     }
 
+    public function coupons()
+    {
+        return $this->hasMany(Coupon::class);
+    }
+
+    public function inventoryMovements()
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
+
+    public function setting()
+    {
+        return $this->hasOne(StoreSetting::class);
+    }
+
     public function orders()
     {
         return $this->hasMany(Order::class);

--- a/app/Models/StoreSetting.php
+++ b/app/Models/StoreSetting.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StoreSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'store_id',
+        'currency',
+        'timezone',
+        'locale',
+        'inventory_tracking',
+        'notifications_enabled',
+        'low_stock_threshold',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'inventory_tracking'    => 'boolean',
+        'notifications_enabled' => 'boolean',
+        'metadata'              => 'array',
+    ];
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -92,8 +92,17 @@ class User extends Authenticatable
         return User::find($id);
     }
     public function animals()
-{
-    return $this->hasMany(Animal::class);
-}
+    {
+        return $this->hasMany(Animal::class);
+    }
 
+    public function createdCoupons()
+    {
+        return $this->hasMany(Coupon::class, 'created_by');
+    }
+
+    public function inventoryMovements()
+    {
+        return $this->hasMany(InventoryMovement::class);
+    }
 }

--- a/app/Policies/CouponPolicy.php
+++ b/app/Policies/CouponPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Coupon;
+use App\Models\User;
+
+class CouponPolicy
+{
+    public function view(User $user, Coupon $coupon): bool
+    {
+        if ($user->can('view_any_coupon')) {
+            return true;
+        }
+
+        if (!$coupon->exists) {
+            return $user->can('view_own_coupon');
+        }
+
+        return $user->can('view_own_coupon') && optional($coupon->store)->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_coupon');
+    }
+
+    public function update(User $user, Coupon $coupon): bool
+    {
+        if ($user->can('edit_any_coupon')) {
+            return true;
+        }
+
+        return $user->can('edit_own_coupon') && optional($coupon->store)->user_id === $user->id;
+    }
+
+    public function delete(User $user, Coupon $coupon): bool
+    {
+        if ($user->can('delete_any_coupon')) {
+            return true;
+        }
+
+        return $user->can('delete_own_coupon') && optional($coupon->store)->user_id === $user->id;
+    }
+}

--- a/app/Policies/InventoryMovementPolicy.php
+++ b/app/Policies/InventoryMovementPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\InventoryMovement;
+use App\Models\User;
+
+class InventoryMovementPolicy
+{
+    public function view(User $user, InventoryMovement $movement): bool
+    {
+        if ($user->can('view_any_inventory_movement')) {
+            return true;
+        }
+
+        if (!$movement->exists) {
+            return $user->can('view_own_inventory_movement');
+        }
+
+        return $user->can('view_own_inventory_movement') && optional($movement->store)->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_inventory_movement');
+    }
+
+    public function update(User $user, InventoryMovement $movement): bool
+    {
+        if ($user->can('edit_any_inventory_movement')) {
+            return true;
+        }
+
+        return $user->can('edit_own_inventory_movement') && optional($movement->store)->user_id === $user->id;
+    }
+
+    public function delete(User $user, InventoryMovement $movement): bool
+    {
+        if ($user->can('delete_any_inventory_movement')) {
+            return true;
+        }
+
+        return $user->can('delete_own_inventory_movement') && optional($movement->store)->user_id === $user->id;
+    }
+}

--- a/app/Policies/StoreSettingPolicy.php
+++ b/app/Policies/StoreSettingPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\StoreSetting;
+use App\Models\User;
+
+class StoreSettingPolicy
+{
+    public function view(User $user, StoreSetting $setting): bool
+    {
+        if ($user->can('view_any_store_setting')) {
+            return true;
+        }
+
+        if (!$setting->exists) {
+            return $user->can('view_own_store_setting');
+        }
+
+        return $user->can('view_own_store_setting') && optional($setting->store)->user_id === $user->id;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_store_setting');
+    }
+
+    public function update(User $user, StoreSetting $setting): bool
+    {
+        if ($user->can('edit_any_store_setting')) {
+            return true;
+        }
+
+        return $user->can('edit_own_store_setting') && optional($setting->store)->user_id === $user->id;
+    }
+
+    public function delete(User $user, StoreSetting $setting): bool
+    {
+        if ($user->can('delete_any_store_setting')) {
+            return true;
+        }
+
+        return $user->can('delete_own_store_setting') && optional($setting->store)->user_id === $user->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,9 @@ use App\Models\Store;
 use App\Models\Order;
 use App\Models\CartItem;
 use App\Models\Product;
+use App\Models\Coupon;
+use App\Models\InventoryMovement;
+use App\Models\StoreSetting;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use Illuminate\Support\Facades\Gate;
@@ -36,6 +39,9 @@ use App\Policies\OrderPolicy;
 use App\Policies\UserPolicy;
 use App\Policies\CartItemPolicy;
 use App\Policies\ProductPolicy;
+use App\Policies\CouponPolicy;
+use App\Policies\InventoryMovementPolicy;
+use App\Policies\StoreSettingPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -61,6 +67,9 @@ class AuthServiceProvider extends ServiceProvider
         Order::class           => OrderPolicy::class,
         CartItem::class        => CartItemPolicy::class,
         User::class            => UserPolicy::class,
+        Coupon::class          => CouponPolicy::class,
+        InventoryMovement::class => InventoryMovementPolicy::class,
+        StoreSetting::class    => StoreSettingPolicy::class,
     ];
 
     public function boot(): void

--- a/app/Services/CouponService.php
+++ b/app/Services/CouponService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Coupon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+
+class CouponService
+{
+    public function list(array $filters = []): LengthAwarePaginator
+    {
+        $query = Coupon::query()->with(['store', 'product', 'creator']);
+
+        if (!empty($filters['store_id'])) {
+            $query->where('store_id', $filters['store_id']);
+        }
+
+        if (!empty($filters['code'])) {
+            $query->where('code', 'like', '%' . $filters['code'] . '%');
+        }
+
+        if (array_key_exists('is_active', $filters)) {
+            $query->where('is_active', (bool) $filters['is_active']);
+        }
+
+        return $query->orderByDesc('created_at')->paginate($filters['per_page'] ?? 15);
+    }
+
+    public function find(int $id): Coupon
+    {
+        return Coupon::with(['store', 'product', 'creator'])->findOrFail($id);
+    }
+
+    public function create(array $data): Coupon
+    {
+        return Coupon::create($data);
+    }
+
+    public function update(Coupon $coupon, array $data): Coupon
+    {
+        $coupon->update($data);
+
+        return $coupon->fresh(['store', 'product', 'creator']);
+    }
+
+    public function delete(Coupon $coupon): void
+    {
+        $coupon->delete();
+    }
+
+    public function forStore(int $storeId): Collection
+    {
+        return Coupon::query()
+            ->where('store_id', $storeId)
+            ->where('is_active', true)
+            ->orderByDesc('created_at')
+            ->get();
+    }
+}

--- a/app/Services/InventoryMovementService.php
+++ b/app/Services/InventoryMovementService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\InventoryMovement;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+
+class InventoryMovementService
+{
+    public function list(array $filters = []): LengthAwarePaginator
+    {
+        $query = InventoryMovement::query()->with(['store', 'product', 'user']);
+
+        if (!empty($filters['store_id'])) {
+            $query->where('store_id', $filters['store_id']);
+        }
+
+        if (!empty($filters['product_id'])) {
+            $query->where('product_id', $filters['product_id']);
+        }
+
+        if (!empty($filters['movement_type'])) {
+            $query->where('movement_type', $filters['movement_type']);
+        }
+
+        return $query->orderByDesc('occurred_at')->paginate($filters['per_page'] ?? 15);
+    }
+
+    public function find(int $id): InventoryMovement
+    {
+        return InventoryMovement::with(['store', 'product', 'user'])->findOrFail($id);
+    }
+
+    public function create(array $data): InventoryMovement
+    {
+        $movement = InventoryMovement::create($data);
+
+        $movement->product->increment('stock', $data['movement_type'] === 'in' ? $data['quantity'] : -$data['quantity']);
+
+        return $movement->fresh(['store', 'product', 'user']);
+    }
+
+    public function update(InventoryMovement $movement, array $data): InventoryMovement
+    {
+        $originalQuantity = $movement->quantity;
+        $originalType = $movement->movement_type;
+
+        $movement->update($data);
+
+        $movement->product->increment('stock', $this->calculateAdjustment($originalType, $originalQuantity, $movement->movement_type, $movement->quantity));
+
+        return $movement->fresh(['store', 'product', 'user']);
+    }
+
+    public function delete(InventoryMovement $movement): void
+    {
+        $movement->product->increment('stock', $movement->movement_type === 'in' ? -$movement->quantity : $movement->quantity);
+        $movement->delete();
+    }
+
+    public function getRecentForStore(int $storeId, int $limit = 10): Collection
+    {
+        return InventoryMovement::query()
+            ->where('store_id', $storeId)
+            ->orderByDesc('occurred_at')
+            ->limit($limit)
+            ->get();
+    }
+
+    private function calculateAdjustment(string $oldType, int $oldQuantity, string $newType, int $newQuantity): int
+    {
+        $adjustment = 0;
+
+        $adjustment += $oldType === 'in' ? -$oldQuantity : $oldQuantity;
+        $adjustment += $newType === 'in' ? $newQuantity : -$newQuantity;
+
+        return $adjustment;
+    }
+}

--- a/app/Services/StoreSettingService.php
+++ b/app/Services/StoreSettingService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\StoreSetting;
+use Illuminate\Database\Eloquent\Collection;
+
+class StoreSettingService
+{
+    public function list(): Collection
+    {
+        return StoreSetting::with('store')->get();
+    }
+
+    public function create(array $data): StoreSetting
+    {
+        return StoreSetting::create($data);
+    }
+
+    public function getByStore(int $storeId): StoreSetting
+    {
+        return StoreSetting::firstOrCreate(['store_id' => $storeId]);
+    }
+
+    public function update(StoreSetting $setting, array $data): StoreSetting
+    {
+        $setting->update($data);
+
+        return $setting->fresh();
+    }
+
+    public function delete(StoreSetting $setting): void
+    {
+        $setting->delete();
+    }
+}

--- a/database/factories/CouponFactory.php
+++ b/database/factories/CouponFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Coupon;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Coupon>
+ */
+class CouponFactory extends Factory
+{
+    protected $model = Coupon::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id'            => Store::factory(),
+            'product_id'          => Product::factory(),
+            'created_by'          => User::factory(),
+            'code'                => strtoupper(Str::random(8)),
+            'name'                => ['fr' => $this->faker->words(2, true), 'en' => $this->faker->words(2, true)],
+            'description'         => ['fr' => $this->faker->sentence(), 'en' => $this->faker->sentence()],
+            'discount_type'       => $this->faker->randomElement(['percentage', 'fixed']),
+            'discount_value'      => $this->faker->randomFloat(2, 5, 20),
+            'minimum_order_total' => $this->faker->randomFloat(2, 0, 200),
+            'usage_limit'         => $this->faker->numberBetween(10, 200),
+            'used_count'          => 0,
+            'starts_at'           => now()->subDays(5),
+            'expires_at'          => now()->addMonth(),
+            'is_active'           => true,
+        ];
+    }
+}

--- a/database/factories/InventoryMovementFactory.php
+++ b/database/factories/InventoryMovementFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\InventoryMovement;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<InventoryMovement>
+ */
+class InventoryMovementFactory extends Factory
+{
+    protected $model = InventoryMovement::class;
+
+    public function definition(): array
+    {
+        return [
+            'store_id'      => Store::factory(),
+            'product_id'    => Product::factory(),
+            'user_id'       => User::factory(),
+            'movement_type' => $this->faker->randomElement(['in', 'out']),
+            'quantity'      => $this->faker->numberBetween(1, 50),
+            'reference'     => $this->faker->uuid(),
+            'notes'         => $this->faker->sentence(),
+            'occurred_at'   => now()->subDays(rand(0, 10)),
+        ];
+    }
+}

--- a/database/migrations/2025_05_24_100000_create_coupons_table.php
+++ b/database/migrations/2025_05_24_100000_create_coupons_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coupons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('code')->unique();
+            $table->json('name');
+            $table->json('description')->nullable();
+            $table->enum('discount_type', ['percentage', 'fixed']);
+            $table->decimal('discount_value', 8, 2);
+            $table->decimal('minimum_order_total', 10, 2)->nullable();
+            $table->unsignedInteger('usage_limit')->nullable();
+            $table->unsignedInteger('used_count')->default(0);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coupons');
+    }
+};

--- a/database/migrations/2025_05_24_100100_create_inventory_movements_table.php
+++ b/database/migrations/2025_05_24_100100_create_inventory_movements_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('inventory_movements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->enum('movement_type', ['in', 'out']);
+            $table->integer('quantity');
+            $table->string('reference')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamp('occurred_at')->useCurrent();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inventory_movements');
+    }
+};

--- a/database/migrations/2025_05_24_100200_create_store_settings_table.php
+++ b/database/migrations/2025_05_24_100200_create_store_settings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('store_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('store_id')->constrained()->cascadeOnDelete();
+            $table->string('currency')->default('EUR');
+            $table->string('timezone')->default('Europe/Paris');
+            $table->string('locale')->default('fr');
+            $table->boolean('inventory_tracking')->default(true);
+            $table->boolean('notifications_enabled')->default(true);
+            $table->unsignedInteger('low_stock_threshold')->default(10);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->unique('store_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('store_settings');
+    }
+};

--- a/database/seeders/CouponSeeder.php
+++ b/database/seeders/CouponSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Coupon;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+
+class CouponSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $store = Store::query()->first() ?? Store::factory()->create();
+        $product = Product::query()->where('store_id', $store->id)->first() ?? Product::factory()->create([
+            'store_id' => $store->id,
+        ]);
+        $creator = User::query()->first() ?? User::factory()->create();
+
+        Coupon::query()->firstOrCreate(
+            ['code' => 'WELCOME10'],
+            [
+                'store_id'        => $store->id,
+                'product_id'      => $product->id,
+                'created_by'      => $creator->id,
+                'name'            => ['fr' => 'Réduction de bienvenue', 'en' => 'Welcome discount'],
+                'description'     => ['fr' => '10% sur votre première commande', 'en' => '10% off your first order'],
+                'discount_type'   => 'percentage',
+                'discount_value'  => 10,
+                'minimum_order_total' => 50,
+                'usage_limit'     => 100,
+                'used_count'      => 0,
+                'starts_at'       => now()->startOfDay(),
+                'expires_at'      => now()->addMonths(3),
+                'is_active'       => true,
+            ]
+        );
+
+        Coupon::factory()->count(2)->create([
+            'store_id'   => $store->id,
+            'product_id' => $product->id,
+            'created_by' => $creator->id,
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,9 @@ class DatabaseSeeder extends Seeder
             ServiceSeeder::class,
             StoreSeeder::class,
             ProductSeeder::class,
+            CouponSeeder::class,
+            InventoryMovementSeeder::class,
+            StoreSettingSeeder::class,
             TestDataSeeder::class,
             MarketplaceSeeder::class
 

--- a/database/seeders/InventoryMovementSeeder.php
+++ b/database/seeders/InventoryMovementSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\InventoryMovement;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+
+class InventoryMovementSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $store = Store::query()->first() ?? Store::factory()->create();
+        $product = Product::query()->where('store_id', $store->id)->first() ?? Product::factory()->create([
+            'store_id' => $store->id,
+        ]);
+        $user = User::query()->first() ?? User::factory()->create();
+
+        InventoryMovement::factory()->count(5)->create([
+            'store_id'   => $store->id,
+            'product_id' => $product->id,
+            'user_id'    => $user->id,
+        ]);
+    }
+}

--- a/database/seeders/StoreSettingSeeder.php
+++ b/database/seeders/StoreSettingSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Store;
+use App\Models\StoreSetting;
+
+class StoreSettingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Store::query()->each(function (Store $store) {
+            StoreSetting::query()->firstOrCreate(
+                ['store_id' => $store->id],
+                [
+                    'currency'               => 'EUR',
+                    'timezone'               => 'Europe/Paris',
+                    'locale'                 => 'fr',
+                    'inventory_tracking'     => true,
+                    'notifications_enabled'  => true,
+                    'low_stock_threshold'    => 10,
+                    'metadata'               => [
+                        'delivery' => ['enabled' => true],
+                    ],
+                ]
+            );
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,10 @@ use App\Http\Controllers\Api\{
     CheckoutController,
     ShippingStatusController,
     PaymentController,
-    StripeWebhookController
+    StripeWebhookController,
+    CouponController,
+    InventoryController,
+    StoreSettingController
 };
 use App\Http\Controllers\Api\ProductCategoryController;
 use App\Http\Controllers\Api\StoreCategoryController;
@@ -100,10 +103,13 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('services', ServiceController::class);
         Route::apiResource('categories', CategoryController::class);
         Route::apiResource('stores', StoreController::class);
+        Route::apiResource('store-settings', StoreSettingController::class);
         Route::get('products/by-user/{userId}', [ProductController::class, 'getByUserId']);
         Route::get('products/my/low-stock', [ProductController::class, 'getMyLowStockProducts']);
         Route::apiResource('products', ProductController::class);
         Route::apiResource('product-categories', ProductCategoryController::class)->except(['index', 'show']);
+        Route::apiResource('coupons', CouponController::class);
+        Route::apiResource('inventory-movements', InventoryController::class);
 
         Route::prefix('store/categories')->group(function () {
             Route::get('my', [StoreCategoryController::class, 'my']);

--- a/tests/Feature/Marketplace/Coupons/CouponApiTest.php
+++ b/tests/Feature/Marketplace/Coupons/CouponApiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Marketplace\Coupons;
+
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class CouponApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $permissions = [
+        'view_any_coupon',
+        'create_coupon',
+        'edit_any_coupon',
+        'delete_any_coupon',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->permissions as $permission) {
+            Permission::create(['name' => $permission]);
+        }
+    }
+
+    public function test_coupon_crud_endpoints(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($this->permissions);
+        Sanctum::actingAs($user);
+
+        $store = Store::factory()->create(['user_id' => $user->id]);
+        $product = Product::factory()->create(['store_id' => $store->id]);
+
+        $createPayload = [
+            'store_id'       => $store->id,
+            'product_id'     => $product->id,
+            'code'           => 'WELCOME10',
+            'name'           => ['fr' => 'Bienvenue', 'en' => 'Welcome'],
+            'description'    => ['fr' => 'Réduction', 'en' => 'Discount'],
+            'discount_type'  => 'percentage',
+            'discount_value' => 10,
+        ];
+
+        $createResponse = $this->postJson('/api/v1/coupons', $createPayload);
+        $createResponse->assertStatus(201)->assertJsonPath('code', 'WELCOME10');
+        $couponId = $createResponse->json('id');
+
+        $this->getJson('/api/v1/coupons')
+            ->assertStatus(200)
+            ->assertJsonFragment(['code' => 'WELCOME10']);
+
+        $this->getJson("/api/v1/coupons/{$couponId}")
+            ->assertStatus(200)
+            ->assertJsonPath('id', $couponId);
+
+        $updatePayload = [
+            'discount_value' => 15,
+            'is_active'      => false,
+        ];
+
+        $this->putJson("/api/v1/coupons/{$couponId}", $updatePayload)
+            ->assertStatus(200)
+            ->assertJsonPath('discount_value', 15.0)
+            ->assertJsonPath('is_active', false);
+
+        $this->deleteJson("/api/v1/coupons/{$couponId}")
+            ->assertStatus(200)
+            ->assertJsonFragment(['message' => 'Coupon deleted']);
+
+        $this->assertDatabaseMissing('coupons', ['id' => $couponId]);
+    }
+}

--- a/tests/Feature/Marketplace/Inventory/InventoryApiTest.php
+++ b/tests/Feature/Marketplace/Inventory/InventoryApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Marketplace\Inventory;
+
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class InventoryApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $permissions = [
+        'view_any_inventory_movement',
+        'create_inventory_movement',
+        'edit_any_inventory_movement',
+        'delete_any_inventory_movement',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->permissions as $permission) {
+            Permission::create(['name' => $permission]);
+        }
+    }
+
+    public function test_inventory_movement_crud_flow(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($this->permissions);
+        Sanctum::actingAs($user);
+
+        $store = Store::factory()->create(['user_id' => $user->id]);
+        $product = Product::factory()->create([
+            'store_id' => $store->id,
+            'stock'    => 10,
+        ]);
+
+        $createPayload = [
+            'store_id'      => $store->id,
+            'product_id'    => $product->id,
+            'movement_type' => 'in',
+            'quantity'      => 5,
+            'reference'     => 'REF-1',
+        ];
+
+        $createResponse = $this->postJson('/api/v1/inventory-movements', $createPayload);
+        $createResponse->assertStatus(201)->assertJsonPath('quantity', 5);
+        $movementId = $createResponse->json('id');
+
+        $product->refresh();
+        $this->assertSame(15, $product->stock);
+
+        $this->getJson('/api/v1/inventory-movements')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $movementId]);
+
+        $this->getJson("/api/v1/inventory-movements/{$movementId}")
+            ->assertStatus(200)
+            ->assertJsonPath('id', $movementId);
+
+        $updatePayload = [
+            'movement_type' => 'out',
+            'quantity'      => 2,
+            'notes'         => 'Correction',
+        ];
+
+        $this->putJson("/api/v1/inventory-movements/{$movementId}", $updatePayload)
+            ->assertStatus(200)
+            ->assertJsonPath('movement_type', 'out')
+            ->assertJsonPath('quantity', 2);
+
+        $product->refresh();
+        $this->assertSame(8, $product->stock);
+
+        $this->deleteJson("/api/v1/inventory-movements/{$movementId}")
+            ->assertStatus(200)
+            ->assertJsonFragment(['message' => 'Inventory movement deleted']);
+
+        $product->refresh();
+        $this->assertSame(10, $product->stock);
+
+        $this->assertDatabaseMissing('inventory_movements', ['id' => $movementId]);
+    }
+}

--- a/tests/Feature/Marketplace/Store/StoreSettingApiTest.php
+++ b/tests/Feature/Marketplace/Store/StoreSettingApiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Marketplace\Store;
+
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class StoreSettingApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $permissions = [
+        'view_any_store_setting',
+        'create_store_setting',
+        'edit_any_store_setting',
+        'delete_any_store_setting',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach ($this->permissions as $permission) {
+            Permission::create(['name' => $permission]);
+        }
+    }
+
+    public function test_store_setting_crud_endpoints(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo($this->permissions);
+        Sanctum::actingAs($user);
+
+        $store = Store::factory()->create(['user_id' => $user->id]);
+
+        $payload = [
+            'store_id'              => $store->id,
+            'currency'              => 'EUR',
+            'timezone'              => 'Europe/Paris',
+            'locale'                => 'fr',
+            'inventory_tracking'    => true,
+            'notifications_enabled' => true,
+            'low_stock_threshold'   => 5,
+        ];
+
+        $createResponse = $this->postJson('/api/v1/store-settings', $payload);
+        $createResponse->assertStatus(201)->assertJsonPath('store_id', $store->id);
+        $settingId = $createResponse->json('id');
+
+        $this->getJson('/api/v1/store-settings')
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $settingId]);
+
+        $this->getJson("/api/v1/store-settings/{$settingId}")
+            ->assertStatus(200)
+            ->assertJsonPath('id', $settingId);
+
+        $updatePayload = [
+            'currency'            => 'USD',
+            'low_stock_threshold' => 3,
+        ];
+
+        $this->putJson("/api/v1/store-settings/{$settingId}", $updatePayload)
+            ->assertStatus(200)
+            ->assertJsonPath('currency', 'USD')
+            ->assertJsonPath('low_stock_threshold', 3);
+
+        $this->deleteJson("/api/v1/store-settings/{$settingId}")
+            ->assertStatus(200)
+            ->assertJsonFragment(['message' => 'Store setting deleted']);
+
+        $this->assertDatabaseMissing('store_settings', ['id' => $settingId]);
+    }
+}

--- a/tests/Unit/Services/CouponServiceTest.php
+++ b/tests/Unit/Services/CouponServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Coupon;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\CouponService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CouponServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CouponService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CouponService();
+    }
+
+    public function test_can_manage_coupons_via_service(): void
+    {
+        $storeOwner = User::factory()->create();
+        $store = Store::factory()->create(['user_id' => $storeOwner->id]);
+        $product = Product::factory()->create(['store_id' => $store->id]);
+
+        $coupon = $this->service->create([
+            'store_id'       => $store->id,
+            'product_id'     => $product->id,
+            'created_by'     => $storeOwner->id,
+            'code'           => 'SERVICE1',
+            'name'           => ['fr' => 'Service', 'en' => 'Service'],
+            'description'    => ['fr' => 'Desc', 'en' => 'Desc'],
+            'discount_type'  => 'fixed',
+            'discount_value' => 5,
+        ]);
+
+        $this->assertInstanceOf(Coupon::class, $coupon);
+        $this->assertDatabaseHas('coupons', ['code' => 'SERVICE1']);
+
+        $found = $this->service->find($coupon->id);
+        $this->assertEquals('SERVICE1', $found->code);
+
+        $list = $this->service->list(['store_id' => $store->id]);
+        $this->assertEquals(1, $list->total());
+
+        $updated = $this->service->update($coupon, ['discount_value' => 10]);
+        $this->assertEquals(10.0, (float) $updated->discount_value);
+
+        $this->service->delete($updated);
+        $this->assertDatabaseMissing('coupons', ['id' => $coupon->id]);
+    }
+}

--- a/tests/Unit/Services/InventoryMovementServiceTest.php
+++ b/tests/Unit/Services/InventoryMovementServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\InventoryMovementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InventoryMovementServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private InventoryMovementService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new InventoryMovementService();
+    }
+
+    public function test_inventory_service_updates_stock_correctly(): void
+    {
+        $user = User::factory()->create();
+        $store = Store::factory()->create(['user_id' => $user->id]);
+        $product = Product::factory()->create([
+            'store_id' => $store->id,
+            'stock'    => 0,
+        ]);
+
+        $movement = $this->service->create([
+            'store_id'      => $store->id,
+            'product_id'    => $product->id,
+            'user_id'       => $user->id,
+            'movement_type' => 'in',
+            'quantity'      => 5,
+        ]);
+
+        $product->refresh();
+        $this->assertSame(5, $product->stock);
+
+        $movement = $this->service->update($movement, [
+            'movement_type' => 'out',
+            'quantity'      => 3,
+        ]);
+
+        $product->refresh();
+        $this->assertSame(-3, $product->stock);
+
+        $this->service->delete($movement);
+
+        $product->refresh();
+        $this->assertSame(0, $product->stock);
+    }
+}

--- a/tests/Unit/Services/StoreSettingServiceTest.php
+++ b/tests/Unit/Services/StoreSettingServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Store;
+use App\Models\StoreSetting;
+use App\Services\StoreSettingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreSettingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private StoreSettingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new StoreSettingService();
+    }
+
+    public function test_manage_store_settings(): void
+    {
+        $store = Store::factory()->create();
+
+        $setting = $this->service->create([
+            'store_id'              => $store->id,
+            'currency'              => 'EUR',
+            'timezone'              => 'Europe/Paris',
+            'locale'                => 'fr',
+            'inventory_tracking'    => true,
+            'notifications_enabled' => true,
+            'low_stock_threshold'   => 5,
+        ]);
+
+        $this->assertInstanceOf(StoreSetting::class, $setting);
+
+        $found = $this->service->getByStore($store->id);
+        $this->assertEquals($setting->id, $found->id);
+
+        $updated = $this->service->update($setting, ['currency' => 'USD']);
+        $this->assertEquals('USD', $updated->currency);
+
+        $this->service->delete($updated);
+        $this->assertDatabaseMissing('store_settings', ['id' => $setting->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add database structure, models, services, and policies for coupons, inventory movements, and store settings
- expose REST controllers, resources, and routes with OpenAPI annotations for the new marketplace features
- seed demo data, extend documentation, and cover the endpoints and services with feature and unit tests

## Testing
- php artisan test *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f5c40b70833398751ab81357c611