### PR TITLE
Fix grouped import commas in API routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -26,8 +26,8 @@ use App\Http\Controllers\Api\{
     StripeWebhookController,
     CouponController,
     InventoryController,
-    StoreSettingController
-    AdminDashboardController
+    StoreSettingController,
+    AdminDashboardController,
 };
 use App\Http\Controllers\Api\ProductCategoryController;
 use App\Http\Controllers\Api\StoreCategoryController;


### PR DESCRIPTION
## Summary
- add missing commas in the grouped API route controller imports to restore valid syntax

## Testing
- php artisan l5-swagger:generate *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f89371f88333be2061b6d3242f37