### PR TITLE
Add Sanctum token expiration example variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
+# Durée en minutes avant l'expiration des tokens personnels Sanctum
+SANCTUM_TOKEN_EXPIRATION=1440
+
 BROADCAST_CONNECTION=log
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database


### PR DESCRIPTION
## Summary
- add SANCTUM_TOKEN_EXPIRATION to the example environment file
- document the variable to clarify the default token lifetime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9516c351c833397e1266d739b6458