### PR TITLE
Update admin dashboard policy role slug handling

### DIFF
--- a/app/Policies/AdminDashboardPolicy.php
+++ b/app/Policies/AdminDashboardPolicy.php
@@ -8,7 +8,7 @@ class AdminDashboardPolicy
 {
     public function viewAny(User $user): bool
     {
-        if ($user->hasAnyRole(['admin', 'super-admin'])) {
+        if ($user->hasAnyRole(['admin', 'super_admin', 'super-admin'])) {
             return true;
         }
 


### PR DESCRIPTION
## Summary
- allow the admin dashboard policy to recognize both `super_admin` and `super-admin` role slugs

## Testing
- php artisan test --filter=AdminDashboardStatsTest *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68d95fbe6e688333a809a93bc3007e86